### PR TITLE
Improve certificate generation to avoid a second deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ gen_terminal_csv : update_dependencies
 	# Add in the edit workspaces and view workspaces cluster roles
 	cp devworkspace-operator/deploy/edit-workspaces-cluster-role.yaml manifests/
 	cp devworkspace-operator/deploy/view-workspaces-cluster-role.yaml manifests/
+	cp devworkspace-operator/deploy/os/service.yaml manifests/web-terminal.service.yaml
 
 ### olm_build_bundle_index: build the terminal bundle and index and push them to a docker registry
 olm_build_bundle_index: _print_vars _check_imgs_env _check_skopeo_installed

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -238,34 +238,6 @@ spec:
           - deletecollection
         serviceAccountName: che-workspace-controller
       deployments:
-      - name: che-workspace-controller-cert-gen
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              app.kubernetes.io/name: cert-generator
-              app.kubernetes.io/part-of: devworkspace-operator
-          strategy: {}
-          template:
-            metadata:
-              annotations:
-                kubectl.kubernetes.io/restartedAt: ""
-              labels:
-                app.kubernetes.io/name: cert-generator
-                app.kubernetes.io/part-of: devworkspace-operator
-            spec:
-              containers:
-              - image: quay.io/che-incubator/che-workspace-controller-cert-gen:nightly
-                imagePullPolicy: Always
-                name: che-workspace-controller-cert-gen
-                resources:
-                  limits:
-                    cpu: 100m
-                    memory: 100Mi
-                  requests:
-                    cpu: 50m
-                    memory: 50Mi
-              serviceAccountName: che-workspace-controller
       - name: che-workspace-controller
         spec:
           replicas: 1
@@ -320,21 +292,14 @@ spec:
                   name: webhook-server
                 resources: {}
                 volumeMounts:
-                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                - mountPath: /apiserver.local.config/certificates/
                   name: webhook-tls-certs
                   readOnly: true
               serviceAccountName: che-workspace-controller
               volumes:
               - name: webhook-tls-certs
-                projected:
-                  sources:
-                  - configMap:
-                      items:
-                      - key: service-ca.crt
-                        path: ./ca.crt
-                      name: devworkspace-controller-secure-service
-                  - secret:
-                      name: devworkspace-controller
+                secret:
+                  secretName: devworkspace-controller
     strategy: deployment
   installModes:
   - supported: false

--- a/manifests/web-terminal.service.yaml
+++ b/manifests/web-terminal.service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: devworkspace-controller
+  labels:
+    app.kubernetes.io/name: devworkspace-controller
+    app.kubernetes.io/part-of: devworkspace-operator
+  name: devworkspace-controller
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: webhook-server
+  selector:
+    app.kubernetes.io/name: devworkspace-controller
+    app.kubernetes.io/part-of: devworkspace-operator
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
### What does this PR do?
This PR uses service instead of cert-generation deployment in WebTerminal Operator Deployment.

It **depends** on PR https://github.com/devfile/devworkspace-operator/pull/121 to work. The generated files are generated from this PR.

### Is it tested? How?
To test this PR the branch from PR https://github.com/devfile/devworkspace-operator/pull/121 should be used (at least, until it's merged to master.)

```bash
rm -rf devworkspace-* generated
# clean up any existing artifacts
kc delete subscriptions.operators.coreos.com web-terminal -n openshift-operators
kc delete csv web-terminal.v1.0.0 -n openshift-operators
for crole in $(kc get clusterrole | grep -E '(workspace|devfile)' | cut -f 1 -d ' ') ; do kc delete clusterrole $crole; done
kc delete service devworkspace-controller -n openshift-operators
# run make uninstall from the devworkspace-operator repo for good measure :)

# deploy bundle
export BUNDLE_IMG=<your-image>
export INDEX_IMG=<your-image>
export DEVWORKSPACE_OPERATOR_VERSION=simplify-webhooks
make gen_terminal_csv
# verify no files are changed
make olm_uninstall olm_build_install_local
# install operator via UI and ensure everything starts up; create a workspace, etc.
```