### PR TITLE
Improve manifest generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 devworkspace-crds
 devworkspace-operator
+devworkspace-dependencies
 generated

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+SHELL := bash
+.SHELLFLAGS = -ec
+
 DEVWORKSPACE_API_VERSION ?= master
 DEVWORKSPACE_OPERATOR_VERSION ?= master
 BUNDLE_IMG ?=
@@ -8,10 +11,10 @@ all: help
 
 _print_vars:
 	@echo "Current env vars:"
-	@echo "    DEVWORKSPACE_API_VERSION=$(DEVWORKSPACE_API_VERSION)"
-	@echo "    DEVWORKSPACE_OPERATOR_VERSION=$(DEVWORKSPACE_OPERATOR_VERSION)"
-	@echo "    BUNDLE_IMG=$(BUNDLE_IMG)"
-	@echo "    INDEX_IMG=$(INDEX_IMG)"
+	echo "    DEVWORKSPACE_API_VERSION=$(DEVWORKSPACE_API_VERSION)"
+	echo "    DEVWORKSPACE_OPERATOR_VERSION=$(DEVWORKSPACE_OPERATOR_VERSION)"
+	echo "    BUNDLE_IMG=$(BUNDLE_IMG)"
+	echo "    INDEX_IMG=$(INDEX_IMG)"
 
 update_dependencies:
 	./collect-sources.sh
@@ -72,10 +75,10 @@ endif
 ### help: print this message
 help: Makefile
 	@echo 'Available rules:'
-	@sed -n 's/^### /    /p' $< | awk 'BEGIN { FS=":" } { printf "%-32s -%s\n", $$1, $$2 }'
-	@echo ''
-	@echo 'Supported environment variables:'
-	@echo '    DEVWORKSPACE_API_VERSION       - Branch or tag of the github.com/devfile/kubernetes-api to depend on. Defaults to master'
-	@echo '    DEVWORKSPACE_OPERATOR_VERSION  - The branch/tag of the terminal manifests'
-	@echo '    BUNDLE_IMG                     - The name of the olm registry bundle image'
-	@echo '    INDEX_IMG                      - The name of the olm registry index image'
+	sed -n 's/^### /    /p' $< | awk 'BEGIN { FS=":" } { printf "%-32s -%s\n", $$1, $$2 }'
+	echo ''
+	echo 'Supported environment variables:'
+	echo '    DEVWORKSPACE_API_VERSION       - Branch or tag of the github.com/devfile/kubernetes-api to depend on. Defaults to master'
+	echo '    DEVWORKSPACE_OPERATOR_VERSION  - The branch/tag of the terminal manifests'
+	echo '    BUNDLE_IMG                     - The name of the olm registry bundle image'
+	echo '    INDEX_IMG                      - The name of the olm registry index image'

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ _print_vars:
 	echo "    DEVWORKSPACE_OPERATOR_VERSION=$(DEVWORKSPACE_OPERATOR_VERSION)"
 	echo "    BUNDLE_IMG=$(BUNDLE_IMG)"
 	echo "    INDEX_IMG=$(INDEX_IMG)"
-
+### update_dependencies: updates files from DevWorkspace API and Operators
 update_dependencies:
 	./update-dependencies.sh
 
-### gen_terminal_csv : generate the csv for a newer version. Refer to gen_terminal_csv makefile definition for extra manual steps that are needed.
+### gen_terminal_csv: generate the csv for a newer version. Refer to gen_terminal_csv makefile definition for extra manual steps that are needed.
 gen_terminal_csv : update_dependencies
 	# Some steps need to be done manually in order to get the csv ready
 	# This includes:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ _print_vars:
 	echo "    INDEX_IMG=$(INDEX_IMG)"
 
 update_dependencies:
-	./collect-sources.sh
+	./update-dependencies.sh
 
 ### gen_terminal_csv : generate the csv for a newer version. Refer to gen_terminal_csv makefile definition for extra manual steps that are needed.
 gen_terminal_csv : update_dependencies

--- a/collect-sources.sh
+++ b/collect-sources.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -e
+set -x
+
+SCRIPT_DIR=${PROJECT_ROOT:-$(cd "$(dirname "$0")" || exit; pwd)}
+
+CRDS_DIR="${SCRIPT_DIR}/devworkspace-crds"
+OPERATOR_DIR="${SCRIPT_DIR}/devworkspace-operator"
+
+CRDS_REPO="https://github.com/devfile/kubernetes-api.git"
+OPERATOR_REPO="https://github.com/devfile/devworkspace-operator.git"
+
+DEVWORKSPACE_API_VERSION=${DEVWORKSPACE_API_VERSION:-"master"}
+DEVWORKSPACE_OPERATOR_VERSION=${DEVWORKSPACE_OPERATOR_VERSION:-"master"}
+
+COMBINED_DIR="${SCRIPT_DIR}/devworkspace-dependencies"
+
+function log() {
+  echo -e "\033[0;31m${1}\033[0m" | sed 's|^|    |'
+}
+
+function update_dep() {
+  local repo=$1
+  local checkout_path=$2
+  local version=$3
+  local save_deploy_files=${4:-"false"}
+  mkdir -p "$checkout_path"
+  pushd "$checkout_path" > /dev/null
+  if [ ! -d .git ]; then
+    git init
+    git remote add origin -f "$repo"
+    git config core.sparsecheckout true
+    echo "deploy/crds/*" > .git/info/sparse-checkout
+    echo "pkg/apis/*" >> .git/info/sparse-checkout
+    if [[ $save_deploy_files == "true" ]]; then
+      echo "deploy/*.yaml" >> .git/info/sparse-checkout
+      echo "deploy/os/*" >> .git/info/sparse-checkout
+    fi
+  else
+    git remote set-url origin "$repo"
+  fi
+  git fetch --tags -p origin
+  if git show-ref --verify "refs/tags/${version}" --quiet; then
+    log 'DevWorkspace API is specified from tag'
+		git checkout "tags/${version}"
+	else
+		log 'DevWorkspace API is specified from branch'
+		git checkout "$version" && git reset --hard "origin/${version}"
+	fi
+  popd > /dev/null
+}
+
+log "checking out repo $CRDS_REPO to $CRDS_DIR with version $DEVWORKSPACE_API_VERSION"
+update_dep "$CRDS_REPO" "$CRDS_DIR" "$DEVWORKSPACE_API_VERSION"
+
+log "checking out repo $OPERATOR_REPO to $OPERATOR_DIR with version $DEVWORKSPACE_OPERATOR_VERSION"
+update_dep "$OPERATOR_REPO" "$OPERATOR_DIR" "$DEVWORKSPACE_OPERATOR_VERSION" "true"
+
+log "merging repos to $COMBINED_DIR"
+mkdir -p "$COMBINED_DIR"
+cp -rn "${OPERATOR_DIR}/"* "${COMBINED_DIR}/"
+cp -rn "${CRDS_DIR}/"* "${COMBINED_DIR}/"
+# Aggregate cluster roles need to be added separately
+rm -rf "${COMBINED_DIR}/deploy/edit-workspaces-cluster-role.yaml"
+rm -rf "${COMBINED_DIR}/deploy/view-workspaces-cluster-role.yaml"
+# Don't care about devworkspacetemplates for now
+rm -rf "${COMBINED_DIR}/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml"

--- a/manifests/edit-workspaces-cluster-role.yaml
+++ b/manifests/edit-workspaces-cluster-role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+    app.kubernetes.io/name: devworkspace-controller
+    app.kubernetes.io/part-of: devworkspace-operator
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: edit-workspaces
 rules:

--- a/manifests/view-workspaces-cluster-role.yaml
+++ b/manifests/view-workspaces-cluster-role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+    app.kubernetes.io/name: devworkspace-controller
+    app.kubernetes.io/part-of: devworkspace-operator
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: view-workspaces

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -5,30 +5,30 @@ metadata:
     alm-examples: |-
       [
         {
-          "kind": "DevWorkspace",
           "apiVersion": "workspace.devfile.io/v1alpha1",
+          "kind": "DevWorkspace",
           "metadata": {
-              "name": "web-terminal",
-              "annotations": {
-                "controller.devfile.io/restricted-access": "true"
-              },
-              "labels": {
-                "console.openshift.io/terminal": "true"
-              }
+            "annotations": {
+              "controller.devfile.io/restricted-access": "true"
+            },
+            "labels": {
+              "console.openshift.io/terminal": "true"
+            },
+            "name": "web-terminal"
           },
           "spec": {
-              "started": true,
-              "routingClass": "web-terminal",
-              "template": {
-                "components": [
-                    {
-                      "plugin": {
-                          "name": "web-terminal",
-                          "id": "redhat-developer/web-terminal/4.5.0"
-                      }
-                    }
-                ]
-              }
+            "routingClass": "web-terminal",
+            "started": true,
+            "template": {
+              "components": [
+                {
+                  "plugin": {
+                    "id": "redhat-developer/web-terminal/4.5.0",
+                    "name": "web-terminal"
+                  }
+                }
+              ]
+            }
           }
         }
       ]
@@ -37,320 +37,329 @@ metadata:
     certified: "false"
     containerImage: quay.io/che-incubator/che-workspace-controller:nightly
     createdAt: "2020-05-27T05:12:57Z"
+    description: Start a Web terminal in your browser with common CLI tools installed
+      to work with cluster
+    operators.operatorframework.io/internal-objects: '["workspaceroutings.controller.devfile.io","components.controller.devfile.io"]'
     repository: https://github.com/devfile/devworkspace-operator
     support: Red Hat, Inc.
-    description: Start a Web terminal in your browser with common CLI tools installed to work with cluster
-    operators.operatorframework.io/internal-objects: '["workspaceroutings.controller.devfile.io","components.controller.devfile.io"]'
   name: web-terminal.v1.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: Component is the Schema for the components API
-        kind: Component
-        name: components.controller.devfile.io
-        version: v1alpha1
-      - description: WorkspaceRouting is the Schema for the workspaceroutings API
-        kind: WorkspaceRouting
-        name: workspaceroutings.controller.devfile.io
-        version: v1alpha1
-      - description: Start a Web terminal in your browser with common CLI tools installed to work with cluster
-        displayName: Workspace
-        kind: DevWorkspace
-        name: devworkspaces.workspace.devfile.io
-        version: v1alpha1
-        specDescriptors:
-          - description: Expected status
-            displayName: Started
-            path: started
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        statusDescriptors:
-          - description: Workspace status
-            displayName: Status
-            path: phase
-            x-descriptors:
-              - urn:alm:descriptor:io.kubernetes.phase
-          - description: Web Terminal ID
-            displayName: ID of the Web Terminal
-            path: workspaceId
-            x-descriptors:
-              - urn:alm:descriptor:text
-          - description: Conditions of the workspace activity
-            displayName: Conditions
-            path: conditions
-            x-descriptors:
-              - urn:alm:descriptor:io.kubernetes.conditions
-  description: Start a Web terminal in your browser with common CLI tools installed to work with cluster
+    - description: Component is the Schema for the components API
+      kind: Component
+      name: components.controller.devfile.io
+      version: v1alpha1
+    - description: Start a Web terminal in your browser with common CLI tools installed
+        to work with cluster
+      displayName: Workspace
+      kind: DevWorkspace
+      name: devworkspaces.workspace.devfile.io
+      specDescriptors:
+      - description: Expected status
+        displayName: Started
+        path: started
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      statusDescriptors:
+      - description: Workspace status
+        displayName: Status
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Web Terminal ID
+        displayName: ID of the Web Terminal
+        path: workspaceId
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Conditions of the workspace activity
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+    - description: WorkspaceRouting is the Schema for the workspaceroutings API
+      kind: WorkspaceRouting
+      name: workspaceroutings.controller.devfile.io
+      version: v1alpha1
+  description: Start a Web terminal in your browser with common CLI tools installed
+    to work with cluster
   displayName: Web Terminal
   install:
     spec:
       clusterPermissions:
-        - rules:
-            - apiGroups:
-                - ""
-              resources:
-                - pods
-                - services
-                - endpoints
-                - persistentvolumeclaims
-                - events
-                - configmaps
-                - secrets
-              verbs:
-                - "*"
-            - apiGroups:
-                - ""
-              resources:
-                - namespaces
-              verbs:
-                - get
-            - apiGroups:
-                - ""
-              resources:
-                - serviceaccounts
-              verbs:
-                - watch
-                - list
-                - get
-                - create
-                - update
-                - patch
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - roles
-                - rolebindings
-              verbs:
-                - watch
-                - list
-                - get
-                - create
-                - update
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - clusterroles
-              verbs:
-                - list
-                - get
-                - watch
-            - apiGroups:
-                - apps
-                - extensions
-              resources:
-                - deployments
-                - replicasets
-              verbs:
-                - "*"
-            - apiGroups:
-                - extensions
-              resources:
-                - ingresses
-              verbs:
-                - "*"
-            - apiGroups:
-                - ""
-                - route.openshift.io
-              resources:
-                - routes
-              verbs:
-                - create
-                - delete
-                - deleteCollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
-                - route.openshift.io
-              resources:
-                - routes/custom-host
-              verbs:
-                - create
-            - apiGroups:
-                - ""
-                - route.openshift.io
-              resources:
-                - routes/status
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - monitoring.coreos.com
-              resources:
-                - servicemonitors
-              verbs:
-                - get
-                - create
-            - apiGroups:
-                - apps
-              resourceNames:
-                - che-workspace-controller
-              resources:
-                - deployments/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - controller.devfile.io
-              resources:
-                - "*"
-              verbs:
-                - "*"
-            - apiGroups:
-                - workspace.devfile.io
-              resources:
-                - "*"
-              verbs:
-                - "*"
-            - apiGroups:
-                - ""
-              resources:
-                - pods/exec
-              verbs:
-                - create
-            - apiGroups:
-                - admissionregistration.k8s.io
-              resources:
-                - mutatingwebhookconfigurations
-                - validatingwebhookconfigurations
-              verbs:
-                - "*"
-            - apiGroups:
-                - oauth.openshift.io
-              resources:
-                - oauthclients
-              verbs:
-                - create
-                - get
-                - delete
-                - list
-                - patch
-                - update
-                - watch
-                - deletecollection
-          serviceAccountName: che-workspace-controller
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - watch
+          - list
+          - get
+          - create
+          - update
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - watch
+          - list
+          - get
+          - create
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - list
+          - get
+          - watch
+        - apiGroups:
+          - apps
+          - extensions
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - '*'
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - deleteCollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - che-workspace-controller
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - controller.devfile.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - workspace.devfile.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods/exec
+          verbs:
+          - create
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - get
+          - delete
+          - list
+          - patch
+          - update
+          - watch
+          - deletecollection
+        serviceAccountName: che-workspace-controller
       deployments:
-        - name: che-workspace-controller
-          spec:
-            replicas: 1
-            selector:
-              matchLabels:
-                app: che-workspace-controller
-            strategy: {}
-            template:
-              metadata:
-                annotations:
-                  kubectl.kubernetes.io/restartedAt: ""
-                labels:
-                  app: che-workspace-controller
-                  app.kubernetes.io/name: devworkspace-controller
-                  app.kubernetes.io/part-of: devworkspace-controller
-              spec:
-                containers:
-                  - env:
-                      - name: WATCH_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.annotations['olm.targetNamespaces']
-                      - name: POD_NAME
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.name
-                      - name: OPERATOR_NAME
-                        value: che-workspace-operator
-                      - name: SERVICE_ACCOUNT_NAME
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: spec.serviceAccountName
-                      - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
-                        value: "quay.io/eclipse/che-machine-exec:nightly"
-                      - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_nightly
-                        value: "quay.io/eclipse/che-machine-exec:nightly"
-                      - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0
-                        value: "quay.io/eclipse/che-machine-exec:nightly"
-                      - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_nightly
-                        value: "quay.io/eclipse/che-machine-exec:nightly"
-                      - name: RELATED_IMAGE_plugin_eclipse_cloud_shell_nightly
-                        value: "quay.io/eclipse/che-machine-exec:nightly"
-                      - name: RELATED_IMAGE_web_terminal_tooling
-                        value: "registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1"
-                      - name: RELATED_IMAGE_openshift_oauth_proxy
-                        value: "openshift/oauth-proxy:latest"
-                    image: quay.io/che-incubator/che-workspace-controller:nightly
-                    imagePullPolicy: Always
-                    name: che-workspace-controller
-                    ports:
-                      - containerPort: 8443
-                        name: webhook-server
-                    resources: {}
-                    volumeMounts:
-                      - mountPath: /tmp/k8s-webhook-server/serving-certs
-                        name: webhook-tls-certs
-                        readOnly: true
-                serviceAccountName: che-workspace-controller
-                volumes:
-                  - name: webhook-tls-certs
-                    projected:
-                      sources:
-                        - configMap:
-                            items:
-                              - key: service-ca.crt
-                                path: ./ca.crt
-                            name: che-workspace-controller-secure-service
-                        - secret:
-                            name: workspace-controller
-        - name: che-workspace-controller-cert-gen
-          spec:
-            replicas: 1
-            selector:
-              matchLabels:
-                app: che-workspace-controller-cert-gen
-            strategy: {}
-            template:
-              metadata:
-                annotations:
-                  kubectl.kubernetes.io/restartedAt: ""
-                labels:
-                  app: che-workspace-controller-cert-gen
-                  app.kubernetes.io/name: devworkspace-controller-cert-gen
-                  app.kubernetes.io/part-of: devworkspace-operator
-              spec:
-                containers:
-                  - image: quay.io/che-incubator/che-workspace-controller-cert-gen:latest
-                    imagePullPolicy: Always
-                    name: che-workspace-controller-cert-gen
-                    resources: {}
-                serviceAccountName: che-workspace-controller
+      - name: che-workspace-controller-cert-gen
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: cert-generator
+              app.kubernetes.io/part-of: devworkspace-operator
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/restartedAt: ""
+              labels:
+                app.kubernetes.io/name: cert-generator
+                app.kubernetes.io/part-of: devworkspace-operator
+            spec:
+              containers:
+              - image: quay.io/che-incubator/che-workspace-controller-cert-gen:nightly
+                imagePullPolicy: Always
+                name: che-workspace-controller-cert-gen
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 100Mi
+                  requests:
+                    cpu: 50m
+                    memory: 50Mi
+              serviceAccountName: che-workspace-controller
+      - name: che-workspace-controller
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: devworkspace-controller
+              app.kubernetes.io/part-of: devworkspace-operator
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/restartedAt: ""
+              labels:
+                app.kubernetes.io/name: devworkspace-controller
+                app.kubernetes.io/part-of: devworkspace-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: che-workspace-operator
+                - name: SERVICE_ACCOUNT_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.serviceAccountName
+                - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
+                  value: quay.io/eclipse/che-machine-exec:nightly
+                - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_nightly
+                  value: quay.io/eclipse/che-machine-exec:nightly
+                - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0
+                  value: quay.io/eclipse/che-machine-exec:nightly
+                - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_nightly
+                  value: quay.io/eclipse/che-machine-exec:nightly
+                - name: RELATED_IMAGE_plugin_eclipse_cloud_shell_nightly
+                  value: quay.io/eclipse/che-machine-exec:nightly
+                - name: RELATED_IMAGE_web_terminal_tooling
+                  value: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1
+                - name: RELATED_IMAGE_openshift_oauth_proxy
+                  value: openshift/oauth-proxy:latest
+                image: quay.io/che-incubator/che-workspace-controller:nightly
+                imagePullPolicy: Always
+                name: che-workspace-controller
+                ports:
+                - containerPort: 8443
+                  name: webhook-server
+                resources: {}
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: webhook-tls-certs
+                  readOnly: true
+              serviceAccountName: che-workspace-controller
+              volumes:
+              - name: webhook-tls-certs
+                projected:
+                  sources:
+                  - configMap:
+                      items:
+                      - key: service-ca.crt
+                        path: ./ca.crt
+                      name: devworkspace-controller-secure-service
+                  - secret:
+                      name: devworkspace-controller
     strategy: deployment
   installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
   keywords:
-    - workspaces
-    - devtools
-    - developer
-    - ide
-    - terminal
-  maintainers:
-    - email: dfestal@redhat.com
-      name: David Festal
-    - email: jpinkney@redhat.com
-      name: Josh Pinkney
-  maturity: alpha
+  - workspaces
+  - devtools
+  - developer
+  - ide
+  - terminal
   links:
-    - name: Web Terminal Repo
-      url: https://github.com/redhat-developer/web-terminal-operator/
+  - name: Web Terminal Repo
+    url: https://github.com/redhat-developer/web-terminal-operator/
+  maintainers:
+  - email: dfestal@redhat.com
+    name: David Festal
+  - email: jpinkney@redhat.com
+    name: Josh Pinkney
+  maturity: alpha
   provider:
     name: Red Hat
   version: 1.0.0

--- a/update-dependencies.sh
+++ b/update-dependencies.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -x
 
 SCRIPT_DIR=${PROJECT_ROOT:-$(cd "$(dirname "$0")" || exit; pwd)}
 
@@ -17,7 +16,11 @@ DEVWORKSPACE_OPERATOR_VERSION=${DEVWORKSPACE_OPERATOR_VERSION:-"master"}
 COMBINED_DIR="${SCRIPT_DIR}/devworkspace-dependencies"
 
 function log() {
-  echo -e "\033[0;31m${1}\033[0m" | sed 's|^|    |'
+  if [ -t 1 ]; then
+    echo "$1" | sed 's|.*|\o033[0;31m&\o033[0m|'
+  else
+    echo "$1"
+  fi
 }
 
 function update_dep() {
@@ -42,22 +45,23 @@ function update_dep() {
   fi
   git fetch --tags -p origin
   if git show-ref --verify "refs/tags/${version}" --quiet; then
-    log 'DevWorkspace API is specified from tag'
+    log 'Version is specified from tag'
 		git checkout "tags/${version}"
 	else
-		log 'DevWorkspace API is specified from branch'
+		log 'Version is specified from branch'
 		git checkout "$version" && git reset --hard "origin/${version}"
 	fi
   popd > /dev/null
 }
 
-log "checking out repo $CRDS_REPO to $CRDS_DIR with version $DEVWORKSPACE_API_VERSION"
+log "Checking out repo '$CRDS_REPO' to '$CRDS_DIR' with version '$DEVWORKSPACE_API_VERSION'"
 update_dep "$CRDS_REPO" "$CRDS_DIR" "$DEVWORKSPACE_API_VERSION"
 
-log "checking out repo $OPERATOR_REPO to $OPERATOR_DIR with version $DEVWORKSPACE_OPERATOR_VERSION"
+log "Checking out repo '$OPERATOR_REPO' to '$OPERATOR_DIR' with version '$DEVWORKSPACE_OPERATOR_VERSION'"
 update_dep "$OPERATOR_REPO" "$OPERATOR_DIR" "$DEVWORKSPACE_OPERATOR_VERSION" "true"
 
-log "merging repos to $COMBINED_DIR"
+log "Merging repos to $COMBINED_DIR"
+rm -rf "$COMBINED_DIR"
 mkdir -p "$COMBINED_DIR"
 cp -rn "${OPERATOR_DIR}/"* "${COMBINED_DIR}/"
 cp -rn "${CRDS_DIR}/"* "${COMBINED_DIR}/"


### PR DESCRIPTION
### What does this PR do?
This PR collects a number of improvements to the CSV generation process.

Commit by commit:

- ce40236 - Move downloading devworkspace-operator and apis to separate script since Makefiles are tedious to write. This new script downloads both repos sparsely, and copies all files into another folder, `devworkspace-dependencies`, which is to be used for CSV generation. 
  - Merging the folders allows us to generate the CSVs directly without the need for manually adding a section for the devworkspace CRD
  - Sparse checkout of the devworkspace-operator repo means we no longer need to filter out irrelevant files from the generated CSV
- 5a1292d - Cleanup makefile and script from code review. Improves logging in the download script and removes `set -x`, which was only set for my debugging.
- f0d4230 - Rework olm bundle and index build to 
    1. Build each image and push to repo
    2. Use skopeo to get the digest for the built image
    3. Use digest in all future references.

  This is necessary since the bundle and index are deployed with `imagePullPolicy: IfNotPresent`, leading to a *lot* of frustration in debugging issues. By using digests for deployed images, we can be certain that the latest changes are picked up when deploying manually.

The generated csv shows a large number of changes but most of it is formatting. To get a more accurate diff, use the script below

```bash
git checkout master
cp manifests/web-terminal.clusterserviceversion.yaml ./master.csv.yaml
git checkout -
# yaml diff: 
# - sort arrays (walk ...), 
# - sort keys in objects (-S flag), 
# - and run through yq (yq -Y) to make formatting the same. 
# You can replace colordiff with diff if you don't want to install it
colordiff -dy -W $(( $(tput cols) - 2 )) \
    <(yq -Y -S 'walk(if type == "array" then sort else . end)' master.csv.yaml) \
    <(yq -Y -S 'walk(if type == "array" then sort else . end)' manifests/web-terminal.clusterserviceversion.yaml)
```

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
```bash
rm -rf devworkspace-* generated
# clean up any existing artifacts
kc delete subscriptions.operators.coreos.com web-terminal -n openshift-operators
kc delete csv web-terminal.v1.0.0 -n openshift-operators
for crole in $(kc get clusterrole | grep -E '(workspace|devfile)' | cut -f 1 -d ' ') ; do kc delete clusterrole $crole; done
kc delete service devworkspace-controller -n openshift-operators
# run make uninstall from the devworkspace-operator repo for good measure :)

# deploy bundle
export BUNDLE_IMG=<your-image>
export INDEX_IMG=<your-image>
make gen_terminal_csv
# verify no files are changed
make olm_uninstall olm_build_install_local
# verify that image is deployed via sha digest
oc get po -n openshift-marketplace -o yaml \
  | yq '.items[] 
    | select(.metadata.generateName == "web-terminal-crd-registry-") 
    | .spec.containers[].image'
# install operator via UI and ensure everything starts up; create a workspace, etc.
```