### PR TITLE
Add export command for helping to verify the bundles in your index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ devworkspace-crds
 devworkspace-operator
 devworkspace-dependencies
 generated
+exported-manifests

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,13 @@ build: _print_vars _check_imgs_env _check_skopeo_installed
 	opm index add -c docker --bundles $${BUNDLE_IMG_DIGEST} --tag $(INDEX_IMG)
 	docker push $(INDEX_IMG)
 
+### export: export the bundles stored in the index to the exported-manifests folder
+export: _print_vars _check_imgs_env
+	rm -rf ./exported-manifests
+	# Export the bundles with the name web-terminal inside of $(INDEX_IMG)
+	# This command basic exports the index back into the old format
+	opm index export -c docker -f exported-manifests -i $(INDEX_IMG) -o web-terminal
+
 ### register_catalogsource: creates the catalogsource to make the operator be available on the marketplace. Must have $(INDEX_IMG) available on docker registry already and have it set to public
 register_catalogsource: _print_vars _check_imgs_env _check_skopeo_installed
 	# replace references of catalogsource img with your image


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR adds a new command called export that exports all the bundles in the web terminal index with the name web-terminal into a folder called exported-manifests.

This is going to be more useful later down the line when we have multiple bundles inside of the index and we want to double-check that all bundles are loaded into the index.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Ran `make export` and checked that all bundles were loaded
