### PR TITLE
Remove OpenShift OAuth Proxy from related images

### DIFF
--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -281,8 +281,6 @@ spec:
                   value: quay.io/eclipse/che-machine-exec:nightly
                 - name: RELATED_IMAGE_web_terminal_tooling
                   value: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1
-                - name: RELATED_IMAGE_openshift_oauth_proxy
-                  value: openshift/oauth-proxy:latest
                 - name: RELATED_IMAGE_devworkspace_webhook_server
                   value: quay.io/devfile/devworkspace-controller:next
                 image: quay.io/devfile/devworkspace-controller:next


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR removes openshift oauth proxy from related images env variables. This is needed because tags -> digest does not work with docker.io/quay and unless a user manually changes to use openshift-oauth as a routing class it shouldn't be an issue

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
