### PR TITLE
Use wto 1.0-x images

### DIFF
--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -317,21 +317,11 @@ spec:
                       fieldPath: spec.serviceAccountName
                 - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
                   value: quay.io/wto/web-terminal-exec:1.0
-                - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_nightly
-                  value: quay.io/eclipse/che-machine-exec:nightly
-                - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0
-                  value: quay.io/wto/web-terminal-exec:1.0
-                - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_nightly
-                  value: quay.io/eclipse/che-machine-exec:nightly
-                - name: RELATED_IMAGE_plugin_eclipse_cloud_shell_nightly
-                  value: quay.io/eclipse/che-machine-exec:nightly
                 - name: RELATED_IMAGE_web_terminal_tooling
-                  value: quay.io/wto/web-terminal-tooling:latest
-                - name: RELATED_IMAGE_openshift_oauth_proxy
-                  value: openshift/oauth-proxy:latest
+                  value: quay.io/wto/web-terminal-tooling:1.0
                 - name: RELATED_IMAGE_devworkspace_webhook_server
-                  value: quay.io/devfile/devworkspace-controller:next
-                image: quay.io/devfile/devworkspace-controller:next
+                  value: quay.io/wto/web-terminal-operator:1.0
+                image: quay.io/wto/web-terminal-operator:1.0
                 imagePullPolicy: Always
                 name: devworkspace-controller
                 resources: {}


### PR DESCRIPTION
### What does this PR do?
This PR sets quay.io/wto/xxx:1.0 images and removes nightly.
It also removes nightlies and dev related images since they are already removed from internal registry: http://pkgs.devel.redhat.com/cgit/containers/web-terminal/tree/internal-registry/redhat-developer/web-terminal/4.5.0?h=web-terminal-1.0-rhel-8

So, in that way, we can test Operator very similar to what we'll have after release.
I know that these changes will be overridden after `make gen_terminal_csv` but the base branch is v1.0.x which is not expected to be changed, right?

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
```
export BUNDLE_IMG=quay.io/sleshche/che-workspace-bundle:v1.0.0
export INDEX_IMG=quay.io/sleshche/che-workspace-operator-index:v1.0.0
make install

kc apply -f ../devworkspace-operator/samples/cloud-shell.yaml
kc get devworkspace
# > workspace is starting forefer
kubectl logs devworkspace-controller-7cf6975689-mrq5x
# {"level":"info","ts":1595593628.0173702,"logger":"registry","msg":"Could not find eclipse/cloud-shell/nightly in the internal registry"}
kc apply -f ../devworkspace-operator/samples/web-terminal.yaml
kc get devworkspace
# workspace is starting forever because of https://issues.redhat.com/browse/WTO-32 :-D 
# ^ it's why that PR was needed - to detect that bug before release
# P.S. Actually I could detect this issue earlier if I tested my previous PR when I switch images to wto ones. 
```
