### PR TITLE
Improve operator uninstalling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ install: _print_vars register_catalogsource
 uninstall:
 	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found) ]
 	then
-		kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait --ignore-not-found=true
+		kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait --ignore-not-found
 	fi
 	# 1. Ensure that all DevWorkspace Custom Resources are removed to avoid issues with finalizers
 	# make sure depending objects are clean up as well
@@ -84,23 +84,23 @@ uninstall:
 		kubectl delete components.controller.devfile.io --all-namespaces --all --wait
 	fi
 	# 2. Uninstall the Operator
-	oc delete subscriptions.operators.coreos.com web-terminal -n openshift-operators --ignore-not-found=true
-	oc delete csv web-terminal.v1.0.0 -n openshift-operators --ignore-not-found=true
+	oc delete subscriptions.operators.coreos.com web-terminal -n openshift-operators --ignore-not-found
+	oc delete csv web-terminal.v1.0.0 -n openshift-operators --ignore-not-found
 	# 3. Remove CRDs
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found=true
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found=true
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found=true
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found
 	# 4. Remove DevWorkspace Webhook Server Deployment itself
-	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
+	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators --ignore-not-found
 	# 5. Remove lingering service, secrets, and configmaps
 	kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
-	kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
-	kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found=true
-	kubectl delete clusterrole devworkspace-webhook-server --ignore-not-found=true
-	kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found=true
+	kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found
+	kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found
+	kubectl delete clusterrole devworkspace-webhook-server --ignore-not-found
+	kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found
 	# 6. Remove mutating/validating webhooks configuration
-	kubectl delete mutatingwebhookconfigurations controller.devfile.io --ignore-not-found=true
-	kubectl delete validatingwebhookconfigurations controller.devfile.io --ignore-not-found=true
+	kubectl delete mutatingwebhookconfigurations controller.devfile.io --ignore-not-found
+	kubectl delete validatingwebhookconfigurations controller.devfile.io --ignore-not-found
 
 _check_imgs_env:
 ifndef BUNDLE_IMG

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ uninstall:
 	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found=true
 	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found=true
 	# 4. Remove DevWorkspace Webhook Server Deployment itself
-	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators
+	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
 	# 5. Remove lingering service, secrets, and configmaps
 	kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
 	kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found=true

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,20 @@ install: _print_vars register_catalogsource
 
 ### uninstall: uninstalls the catalog source along with operator subscription
 uninstall:
+	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found) ]
+	then
+		kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait --ignore-not-found=true
+	fi
 	# 1. Ensure that all DevWorkspace Custom Resources are removed to avoid issues with finalizers
-	kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait
 	# make sure depending objects are clean up as well
-	kubectl delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
-	kubectl delete components.controller.devfile.io --all-namespaces --all --wait
+	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found) ]
+	then
+		kubectl delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
+	fi
+	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found) ]
+	then
+		kubectl delete components.controller.devfile.io --all-namespaces --all --wait
+	fi
 	# 2. Uninstall the Operator
 	oc delete subscriptions.operators.coreos.com web-terminal -n openshift-operators --ignore-not-found=true
 	oc delete csv web-terminal.v1.0.0 -n openshift-operators --ignore-not-found=true

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ uninstall:
 	kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
 	kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
 	kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found=true
-	kubectl delete clusterrole devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
+	kubectl delete clusterrole devworkspace-webhook-server --ignore-not-found=true
 	kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found=true
 	# 6. Remove mutating/validating webhooks configuration
 	kubectl delete mutatingwebhookconfigurations controller.devfile.io --ignore-not-found=true

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -122,7 +122,7 @@ spec:
             kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
             kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
             kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found=true
-            kubectl delete clusterrole devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
+            kubectl delete clusterrole devworkspace-webhook-server --ignore-not-found=true
             kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found=true
 
     6. Remove mutating/validating webhook configurations. _note:_ there may be a few seconds where you cannot exec into

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -115,7 +115,7 @@ spec:
 
     4. Remove DevWorkspace Webhook Server Deployment itself
 
-            kubectl delete deployment/devworkspace-webhook-server -n openshift-operators
+            kubectl delete deployment/devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
 
     5. Remove lingering service, secrets, and configmaps
 

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -109,27 +109,27 @@ spec:
 
     3. Remove the custom resource definitions
 
-            kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found=true
-            kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found=true
-            kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found=true
+            kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found
+            kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found
+            kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found
 
     4. Remove DevWorkspace Webhook Server Deployment itself
 
-            kubectl delete deployment/devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
+            kubectl delete deployment/devworkspace-webhook-server -n openshift-operators --ignore-not-found
 
     5. Remove lingering service, secrets, and configmaps
 
             kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
-            kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
-            kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found=true
-            kubectl delete clusterrole devworkspace-webhook-server --ignore-not-found=true
-            kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found=true
+            kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found
+            kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found
+            kubectl delete clusterrole devworkspace-webhook-server --ignore-not-found
+            kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found
 
     6. Remove mutating/validating webhook configurations. _note:_ there may be a few seconds where you cannot exec into
        pods between steps 4 and 6. This is expected. Once you remove the webhooks you will be able to exec into pods again.
 
-            kubectl delete mutatingwebhookconfigurations controller.devfile.io --ignore-not-found=true
-            kubectl delete validatingwebhookconfigurations controller.devfile.io --ignore-not-found=true
+            kubectl delete mutatingwebhookconfigurations controller.devfile.io --ignore-not-found
+            kubectl delete validatingwebhookconfigurations controller.devfile.io --ignore-not-found
 
 
   displayName: Web Terminal


### PR DESCRIPTION
### What does this PR do?
This PR improves operator uninstalling:
1. `make uninstall` does not fail and clean up other resources if CRDs are removed by someone else.
I believe for Operator description that is not critical since admins are supposed to copy/paste section by section.

2. Remove namespace while removing the cluster role to avoid warning that it's not a namespace-scoped object.

3. Does not fail if webhook server deployment is already removed.
^ I thought about if there is any sense to fail and it may - like it helps us to make sure that we remove right objects and if we remove objects and forget about that here - it will be easier to figure it out... So, as an alternative I see we have two makefile rules: uninstall - fail if not found, purge  - try to remove everything without failing ( I got it from helm argument for uninstall )
But it can be done separately from that PR since we already have a lot if ignore-not-found.

4. The value of flag --ignore-not-found is you specify it - is true. So no need to specify it explicitly.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
execute `make uninstall` twice.
