### PR TITLE
Cherry-pick changes related to uninstallation procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,40 +67,32 @@ build_install: _print_vars build install
 install: _print_vars register_catalogsource
 	oc apply -f ./operator-subscription.yaml
 
-### uninstall: uninstalls the catalog source along with operator subscription
+### uninstall: uninstalls the Web Terminal Operator in the proper way described in documentation
 uninstall:
-	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found) ]
-	then
-		kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait --ignore-not-found
-	fi
 	# 1. Ensure that all DevWorkspace Custom Resources are removed to avoid issues with finalizers
 	# make sure depending objects are clean up as well
-	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found) ]
-	then
-		kubectl delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
-	fi
-	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found) ]
-	then
-		kubectl delete components.controller.devfile.io --all-namespaces --all --wait
-	fi
+	kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait
+	kubectl delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
+	kubectl delete components.controller.devfile.io --all-namespaces --all --wait
 	# 2. Uninstall the Operator
-	oc delete subscriptions.operators.coreos.com web-terminal -n openshift-operators --ignore-not-found
-	oc delete csv web-terminal.v1.0.0 -n openshift-operators --ignore-not-found
+	kubectl delete subscriptions.operators.coreos.com web-terminal -n openshift-operators
 	# 3. Remove CRDs
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io
 	# 4. Remove DevWorkspace Webhook Server Deployment itself
-	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators --ignore-not-found
+	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators
 	# 5. Remove lingering service, secrets, and configmaps
 	kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
-	kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found
-	kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found
-	kubectl delete clusterrole devworkspace-webhook-server --ignore-not-found
-	kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found
+	kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators
+	kubectl delete configmap devworkspace-controller -n openshift-operators
+	kubectl delete clusterrole devworkspace-webhook-server
+	kubectl delete clusterrolebinding devworkspace-webhook-server
 	# 6. Remove mutating/validating webhooks configuration
-	kubectl delete mutatingwebhookconfigurations controller.devfile.io --ignore-not-found
-	kubectl delete validatingwebhookconfigurations controller.devfile.io --ignore-not-found
+	kubectl delete mutatingwebhookconfigurations controller.devfile.io
+	kubectl delete validatingwebhookconfigurations controller.devfile.io
+	# Extra step that is not described in admin guide
+	kubectl delete csv web-terminal.v1.0.0 -n openshift-operators
 
 _check_imgs_env:
 ifndef BUNDLE_IMG

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,42 @@ uninstall:
 	# Extra step that is not described in admin guide
 	kubectl delete csv web-terminal.v1.0.0 -n openshift-operators
 
+### purge: uninstalls the Web Terminal Operator in the safe way where every object is removed without failing when not found. Use it if uninstall fails because of no objects found
+purge:
+	# 1. Ensure that all DevWorkspace Custom Resources are removed to avoid issues with finalizers
+	# make sure depending objects are clean up as well
+	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found) ]
+	then
+		kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait
+	fi
+	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found) ]
+	then
+		kubectl delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
+	fi
+	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found) ]
+	then
+		kubectl delete components.controller.devfile.io --all-namespaces --all --wait
+	fi
+	# 2. Uninstall the Operator
+	kubectl delete subscriptions.operators.coreos.com web-terminal -n openshift-operators --ignore-not-found
+	# 3. Remove CRDs
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found
+	# 4. Remove DevWorkspace Webhook Server Deployment itself
+	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators --ignore-not-found
+	# 5. Remove lingering service, secrets, and configmaps
+	kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
+	kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found
+	kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found
+	kubectl delete clusterrole devworkspace-webhook-server --ignore-not-found
+	kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found
+	# 6. Remove mutating/validating webhooks configuration
+	kubectl delete mutatingwebhookconfigurations controller.devfile.io --ignore-not-found
+	kubectl delete validatingwebhookconfigurations controller.devfile.io --ignore-not-found
+	# Extra step that is not described in admin guide
+	kubectl delete csv web-terminal.v1.0.0 -n openshift-operators --ignore-not-found
+
 _check_imgs_env:
 ifndef BUNDLE_IMG
 	$(error "BUNDLE_IMG not set")

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ install: _print_vars register_catalogsource
 uninstall:
 	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found) ]
 	then
-		kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait --ignore-not-found=true
+		kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait --ignore-not-found
 	fi
 	# 1. Ensure that all DevWorkspace Custom Resources are removed to avoid issues with finalizers
 	# make sure depending objects are clean up as well
@@ -84,23 +84,23 @@ uninstall:
 		kubectl delete components.controller.devfile.io --all-namespaces --all --wait
 	fi
 	# 2. Uninstall the Operator
-	oc delete subscriptions.operators.coreos.com web-terminal -n openshift-operators --ignore-not-found=true
-	oc delete csv web-terminal.v1.0.0 -n openshift-operators --ignore-not-found=true
+	oc delete subscriptions.operators.coreos.com web-terminal -n openshift-operators --ignore-not-found
+	oc delete csv web-terminal.v1.0.0 -n openshift-operators --ignore-not-found
 	# 3. Remove CRDs
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found=true
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found=true
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found=true
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found
 	# 4. Remove DevWorkspace Webhook Server Deployment itself
-	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators
+	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators --ignore-not-found
 	# 5. Remove lingering service, secrets, and configmaps
 	kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
-	kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
-	kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found=true
-	kubectl delete clusterrole devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
-	kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found=true
+	kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found
+	kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found
+	kubectl delete clusterrole devworkspace-webhook-server --ignore-not-found
+	kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found
 	# 6. Remove mutating/validating webhooks configuration
-	kubectl delete mutatingwebhookconfigurations controller.devfile.io --ignore-not-found=true
-	kubectl delete validatingwebhookconfigurations controller.devfile.io --ignore-not-found=true
+	kubectl delete mutatingwebhookconfigurations controller.devfile.io --ignore-not-found
+	kubectl delete validatingwebhookconfigurations controller.devfile.io --ignore-not-found
 
 _check_imgs_env:
 ifndef BUNDLE_IMG

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,20 @@ install: _print_vars register_catalogsource
 
 ### uninstall: uninstalls the catalog source along with operator subscription
 uninstall:
+	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found) ]
+	then
+		kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait --ignore-not-found=true
+	fi
 	# 1. Ensure that all DevWorkspace Custom Resources are removed to avoid issues with finalizers
-	kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait
 	# make sure depending objects are clean up as well
-	kubectl delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
-	kubectl delete components.controller.devfile.io --all-namespaces --all --wait
+	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found) ]
+	then
+		kubectl delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
+	fi
+	if [ ! -z $(kubectl get customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found) ]
+	then
+		kubectl delete components.controller.devfile.io --all-namespaces --all --wait
+	fi
 	# 2. Uninstall the Operator
 	oc delete subscriptions.operators.coreos.com web-terminal -n openshift-operators --ignore-not-found=true
 	oc delete csv web-terminal.v1.0.0 -n openshift-operators --ignore-not-found=true

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -109,27 +109,27 @@ spec:
 
     3. Remove the custom resource definitions
 
-            kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found
-            kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found
-            kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found
+            kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io
+            kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io
+            kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io
 
     4. Remove DevWorkspace Webhook Server Deployment itself
 
-            kubectl delete deployment/devworkspace-webhook-server -n openshift-operators --ignore-not-found
+            kubectl delete deployment/devworkspace-webhook-server -n openshift-operators
 
     5. Remove lingering service, secrets, and configmaps
 
             kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
-            kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found
-            kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found
-            kubectl delete clusterrole devworkspace-webhook-server --ignore-not-found
-            kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found
+            kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators
+            kubectl delete configmap devworkspace-controller -n openshift-operators
+            kubectl delete clusterrole devworkspace-webhook-server
+            kubectl delete clusterrolebinding devworkspace-webhook-server
 
     6. Remove mutating/validating webhook configurations. _note:_ there may be a few seconds where you cannot exec into
        pods between steps 4 and 6. This is expected. Once you remove the webhooks you will be able to exec into pods again.
 
-            kubectl delete mutatingwebhookconfigurations controller.devfile.io --ignore-not-found
-            kubectl delete validatingwebhookconfigurations controller.devfile.io --ignore-not-found
+            kubectl delete mutatingwebhookconfigurations controller.devfile.io
+            kubectl delete validatingwebhookconfigurations controller.devfile.io
 
 
   displayName: Web Terminal

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -109,27 +109,27 @@ spec:
 
     3. Remove the custom resource definitions
 
-            kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found=true
-            kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found=true
-            kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found=true
+            kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found
+            kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found
+            kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io --ignore-not-found
 
     4. Remove DevWorkspace Webhook Server Deployment itself
 
-            kubectl delete deployment/devworkspace-webhook-server -n openshift-operators
+            kubectl delete deployment/devworkspace-webhook-server -n openshift-operators --ignore-not-found
 
     5. Remove lingering service, secrets, and configmaps
 
             kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
-            kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
-            kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found=true
-            kubectl delete clusterrole devworkspace-webhook-server -n openshift-operators --ignore-not-found=true
-            kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found=true
+            kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators --ignore-not-found
+            kubectl delete configmap devworkspace-controller -n openshift-operators --ignore-not-found
+            kubectl delete clusterrole devworkspace-webhook-server --ignore-not-found
+            kubectl delete clusterrolebinding devworkspace-webhook-server --ignore-not-found
 
     6. Remove mutating/validating webhook configurations. _note:_ there may be a few seconds where you cannot exec into
        pods between steps 4 and 6. This is expected. Once you remove the webhooks you will be able to exec into pods again.
 
-            kubectl delete mutatingwebhookconfigurations controller.devfile.io --ignore-not-found=true
-            kubectl delete validatingwebhookconfigurations controller.devfile.io --ignore-not-found=true
+            kubectl delete mutatingwebhookconfigurations controller.devfile.io --ignore-not-found
+            kubectl delete validatingwebhookconfigurations controller.devfile.io --ignore-not-found
 
 
   displayName: Web Terminal


### PR DESCRIPTION
### What does this PR do?
Cherry-pick changes related to uninstallation procedure:
https://github.com/redhat-developer/web-terminal-operator/pull/16
https://github.com/redhat-developer/web-terminal-operator/pull/17

It's mainly done to align make uninstall rule with documentation and a few fixes - like remove namespace for cluster-scope objects.

It's my first time when I tried successfully use `git rebase --onto` =)

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
I haven't tested it manually but I'm going to before merging.
