### PR TITLE
Port changes from v1.0.x and rename catalog source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ register_catalogsource: _print_vars _check_imgs_env _check_skopeo_installed
 
 ### unregister_catalogsource: remove the catalogsource from the cluster.
 unregister_catalogsource: _print_vars
-	@oc delete -f ./catalog-source.yaml
+	@oc delete -f ./catalog-source.yaml --ignore-not-found=true
 
 ### build_install: build the catalog and create catalogsource and operator subscription on the cluster
 build_install: _print_vars build install

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ register_catalogsource: _print_vars _check_imgs_env _check_skopeo_installed
 
 	# replace references of catalogsource img with your image
 	sed -i.bak -e "s|quay.io/che-incubator/che-workspace-operator-index:latest|$${INDEX_IMG_DIGEST}|g" ./catalog-source.yaml
-	# use || to make sure we undo changes to catalog-source.yaml even if command fails.
-	oc apply -f ./catalog-source.yaml ||\
-	mv ./catalog-source.yaml.bak ./catalog-source.yaml
+	# use ';' to make sure we undo changes to catalog-source.yaml even if command fails.
+	oc apply -f ./catalog-source.yaml ; \
+	  mv ./catalog-source.yaml.bak ./catalog-source.yaml
 
 ### unregister_catalogsource: remove the catalogsource from the cluster.
 unregister_catalogsource: _print_vars

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 SHELL := bash
 .SHELLFLAGS = -ec
 
-DEVWORKSPACE_API_VERSION ?= master
-DEVWORKSPACE_OPERATOR_VERSION ?= master
 BUNDLE_IMG ?= quay.io/wto/web-terminal-operator-metadata:next
 INDEX_IMG ?= quay.io/wto/web-terminal-operator-index:next
 
@@ -11,8 +9,6 @@ all: help
 
 _print_vars:
 	@echo "Current env vars:"
-	echo "    DEVWORKSPACE_API_VERSION=$(DEVWORKSPACE_API_VERSION)"
-	echo "    DEVWORKSPACE_OPERATOR_VERSION=$(DEVWORKSPACE_OPERATOR_VERSION)"
 	echo "    BUNDLE_IMG=$(BUNDLE_IMG)"
 	echo "    INDEX_IMG=$(INDEX_IMG)"
 ### update_dependencies: updates files from DevWorkspace API and Operators
@@ -157,7 +153,7 @@ help: Makefile
 	sed -n 's/^### /    /p' $< | awk 'BEGIN { FS=":" } { printf "%-34s -%s\n", $$1, $$2 }'
 	echo ''
 	echo 'Supported environment variables:'
-	echo '    BUNDLE_IMG                     - The name of the olm registry bundle image.                             Current value: $(BUNDLE_IMG)'
-	echo '    INDEX_IMG                      - The name of the olm registry index image.                              Current value: $(INDEX_IMG)'
-	echo '    DEVWORKSPACE_API_VERSION       - Branch or tag of the github.com/devfile/kubernetes-api to depend on.   Current value: $(DEVWORKSPACE_API_VERSION)'
-	echo '    DEVWORKSPACE_OPERATOR_VERSION  - The branch/tag of the terminal manifests.                              Current value: $(DEVWORKSPACE_OPERATOR_VERSION)'
+	echo '    BUNDLE_IMG                     - The name of the olm registry bundle image. Set to $(BUNDLE_IMG)'
+	echo '    INDEX_IMG                      - The name of the olm registry index image. Set to $(INDEX_IMG)'
+	echo '    DEVWORKSPACE_API_VERSION       - Branch or tag of the github.com/devfile/kubernetes-api to depend on.'
+	echo '    DEVWORKSPACE_OPERATOR_VERSION  - The branch/tag of the terminal manifests.'

--- a/catalog-source.yaml
+++ b/catalog-source.yaml
@@ -1,11 +1,10 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: web-terminal-crd-registry
+  name: custom-web-terminal-catalog
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  # This image will need to be replaced when we create the first release
   image: quay.io/che-incubator/che-workspace-operator-index:latest
   publisher: Red Hat
   displayName: Web Terminal Operator Catalog

--- a/manifests/controller.devfile.io_components_crd.yaml
+++ b/manifests/controller.devfile.io_components_crd.yaml
@@ -35,10 +35,60 @@ spec:
               description: Commands from devfile, to be matched to components
               items:
                 properties:
+                  apply:
+                    description: "Command that consists in applying a given component\
+                      \ definition, typically bound to a workspace event. \n For example,\
+                      \ when an `apply` command is bound to a `preStart` event, and\
+                      \ references a `container` component, it will start the container\
+                      \ as a K8S initContainer in the workspace POD, unless the component\
+                      \ has its `dedicatedPod` field set to `true`. \n When no `apply`\
+                      \ command exist for a given component, it is assumed the component\
+                      \ will be applied at workspace start by default."
+                    properties:
+                      attributes:
+                        additionalProperties:
+                          type: string
+                        description: Optional map of free-form additional command
+                          attributes
+                        type: object
+                      component:
+                        description: Describes component that will be applied
+                        type: string
+                      group:
+                        description: Defines the group this command is part of
+                        properties:
+                          isDefault:
+                            description: Identifies the default command for a given
+                              group kind
+                            type: boolean
+                          kind:
+                            description: Kind of group the command is part of
+                            enum:
+                              - build
+                              - run
+                              - test
+                              - debug
+                            type: string
+                        required:
+                          - kind
+                        type: object
+                      id:
+                        description: Mandatory identifier that allows referencing
+                          this command in composite commands, from a parent, or in
+                          events.
+                        type: string
+                      label:
+                        description: Optional label that provides a label for this
+                          command to be used in Editor UI menus for example
+                        type: string
+                    required:
+                      - id
+                    type: object
                   commandType:
                     description: Type of workspace command
                     enum:
                       - Exec
+                      - Apply
                       - VscodeTask
                       - VscodeLaunch
                       - Composite
@@ -79,8 +129,8 @@ spec:
                         type: object
                       id:
                         description: Mandatory identifier that allows referencing
-                          this command in composite commands, or from a parent, or
-                          in events.
+                          this command in composite commands, from a parent, or in
+                          events.
                         type: string
                       label:
                         description: Optional label that provides a label for this
@@ -136,8 +186,8 @@ spec:
                         type: object
                       id:
                         description: Mandatory identifier that allows referencing
-                          this command in composite commands, or from a parent, or
-                          in events.
+                          this command in composite commands, from a parent, or in
+                          events.
                         type: string
                       label:
                         description: Optional label that provides a label for this
@@ -149,7 +199,7 @@ spec:
                       - id
                     type: object
                   exec:
-                    description: CLI Command executed in a component container
+                    description: CLI Command executed in an existing component container
                     properties:
                       attributes:
                         additionalProperties:
@@ -158,7 +208,12 @@ spec:
                           attributes
                         type: object
                       commandLine:
-                        description: The actual command-line string
+                        description: "The actual command-line string \n Special variables\
+                          \ that can be used: \n  - `$PROJECTS_ROOT`: A path where\
+                          \ projects sources are mounted \n  - `$PROJECT_SOURCE`:\
+                          \ A path to a project source ($PROJECTS_ROOT/<project-name>).\
+                          \ If there are multiple projects, this will point to the\
+                          \ directory of the first one."
                         type: string
                       component:
                         description: Describes component to which given action relates
@@ -195,18 +250,29 @@ spec:
                         required:
                           - kind
                         type: object
+                      hotReloadCapable:
+                        description: "Whether the command is capable to reload itself\
+                          \ when source code changes. If set to `true` the command\
+                          \ won't be restarted and it is expected to handle file changes\
+                          \ on its own. \n Default value is `false`"
+                        type: boolean
                       id:
                         description: Mandatory identifier that allows referencing
-                          this command in composite commands, or from a parent, or
-                          in events.
+                          this command in composite commands, from a parent, or in
+                          events.
                         type: string
                       label:
                         description: Optional label that provides a label for this
                           command to be used in Editor UI menus for example
                         type: string
                       workingDir:
-                        description: Working directory where the command should be
-                          executed
+                        description: "Working directory where the command should be\
+                          \ executed \n Special variables that can be used: \n  -\
+                          \ `${PROJECTS_ROOT}`: A path where projects sources are\
+                          \ mounted \n  - `${PROJECT_SOURCE}`: A path to a project\
+                          \ source (${PROJECTS_ROOT}/<project-name>). If there are\
+                          \ multiple projects, this will point to the directory of\
+                          \ the first one."
                         type: string
                     required:
                       - id
@@ -241,8 +307,8 @@ spec:
                         type: object
                       id:
                         description: Mandatory identifier that allows referencing
-                          this command in composite commands, or from a parent, or
-                          in events.
+                          this command in composite commands, from a parent, or in
+                          events.
                         type: string
                       inlined:
                         description: Inlined content of the VsCode configuration
@@ -289,8 +355,8 @@ spec:
                         type: object
                       id:
                         description: Mandatory identifier that allows referencing
-                          this command in composite commands, or from a parent, or
-                          in events.
+                          this command in composite commands, from a parent, or in
+                          events.
                         type: string
                       inlined:
                         description: Inlined content of the VsCode configuration
@@ -328,59 +394,83 @@ spec:
                     description: Allows adding and configuring workspace-related containers
                     properties:
                       args:
-                        description: The arguments to supply to the command running
-                          the dockerimage component. The arguments are supplied either
-                          to the default command provided in the image or to the overridden
-                          command. Defaults to an empty array, meaning use whatever
-                          is defined in the image.
+                        description: "The arguments to supply to the command running\
+                          \ the dockerimage component. The arguments are supplied\
+                          \ either to the default command provided in the image or\
+                          \ to the overridden command. \n Defaults to an empty array,\
+                          \ meaning use whatever is defined in the image."
                         items:
                           type: string
                         type: array
                       command:
-                        description: The command to run in the dockerimage component
-                          instead of the default one provided in the image. Defaults
-                          to an empty array, meaning use whatever is defined in the
-                          image.
+                        description: "The command to run in the dockerimage component\
+                          \ instead of the default one provided in the image. \n Defaults\
+                          \ to an empty array, meaning use whatever is defined in\
+                          \ the image."
                         items:
                           type: string
                         type: array
+                      dedicatedPod:
+                        description: "Specify if a container should run in its own\
+                          \ separated pod, instead of running as part of the main\
+                          \ development environment pod. \n Default value is `false`"
+                        type: boolean
                       endpoints:
                         items:
                           properties:
                             attributes:
                               additionalProperties:
                                 type: string
+                              description: "Map of implementation-dependant string-based\
+                                \ free-form attributes. \n Examples of Che-specific\
+                                \ attributes: \n - cookiesAuthEnabled: \"true\" /\
+                                \ \"false\", \n - type: \"terminal\" / \"ide\" / \"\
+                                ide-dev\","
                               type: object
-                            configuration:
-                              properties:
-                                cookiesAuthEnabled:
-                                  type: boolean
-                                discoverable:
-                                  type: boolean
-                                path:
-                                  type: string
-                                protocol:
-                                  description: The is the low-level protocol of traffic
-                                    coming through this endpoint. Default value is
-                                    "tcp"
-                                  type: string
-                                public:
-                                  type: boolean
-                                scheme:
-                                  description: The is the URL scheme to use when accessing
-                                    the endpoint. Default value is "http"
-                                  type: string
-                                secure:
-                                  type: boolean
-                                type:
-                                  enum:
-                                    - ide
-                                    - terminal
-                                    - ide-dev
-                                  type: string
-                              type: object
+                            exposure:
+                              description: "Describes how the endpoint should be exposed\
+                                \ on the network. \n - `public` means that the endpoint\
+                                \ will be exposed on the public network, typically\
+                                \ through a K8S ingress or an OpenShift route. \n\
+                                \ - `internal` means that the endpoint will be exposed\
+                                \ internally outside of the main workspace POD, typically\
+                                \ by K8S services, to be consumed by other elements\
+                                \ running on the same cloud internal network. \n -\
+                                \ `none` means that the endpoint will not be exposed\
+                                \ and will only be accessible inside the main workspace\
+                                \ POD, on a local address. \n Default value is `public`"
+                              enum:
+                                - public
+                                - internal
+                                - none
+                              type: string
                             name:
                               type: string
+                            path:
+                              description: Path of the endpoint URL
+                              type: string
+                            protocol:
+                              description: "Describes the application and transport\
+                                \ protocols of the traffic that will go through this\
+                                \ endpoint. \n - `http`: Endpoint will have `http`\
+                                \ traffic, typically on a TCP connection. It will\
+                                \ be automaticaly promoted to `https` when the `secure`\
+                                \ field is set to `true`. \n - `https`: Endpoint will\
+                                \ have `https` traffic, typically on a TCP connection.\
+                                \ \n - `ws`: Endpoint will have `ws` traffic, typically\
+                                \ on a TCP connection. It will be automaticaly promoted\
+                                \ to `wss` when the `secure` field is set to `true`.\
+                                \ \n - `wss`: Endpoint will have `wss` traffic, typically\
+                                \ on a TCP connection. \n - `tcp`: Endpoint will have\
+                                \ traffic on a TCP connection, without specifying\
+                                \ an application protocol. \n - `udp`: Endpoint will\
+                                \ have traffic on an UDP connection, without specifying\
+                                \ an application protocol. \n Default value is `http`"
+                              type: string
+                            secure:
+                              description: Describes whether the endpoint should be
+                                secured and protected by some authentication process
+                              type: boolean
                             targetPort:
                               type: integer
                           required:
@@ -423,11 +513,10 @@ spec:
                           properties:
                             name:
                               description: The volume mount name is the name of an
-                                existing `Volume` component. If no corresponding `Volume`
-                                component exist it is implicitly added. If several
-                                containers mount the same volume name then they will
-                                reuse the same volume and will be able to access to
-                                the same files.
+                                existing `Volume` component. If several containers
+                                mount the same volume name then they will reuse the
+                                same volume and will be able to access to the same
+                                files.
                               type: string
                             path:
                               description: The path in the component container where
@@ -473,6 +562,68 @@ spec:
                       reusing the Kubernetes definitions used to deploy some runtime
                       components in production.
                     properties:
+                      endpoints:
+                        items:
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                type: string
+                              description: "Map of implementation-dependant string-based\
+                                \ free-form attributes. \n Examples of Che-specific\
+                                \ attributes: \n - cookiesAuthEnabled: \"true\" /\
+                                \ \"false\", \n - type: \"terminal\" / \"ide\" / \"\
+                                ide-dev\","
+                              type: object
+                            exposure:
+                              description: "Describes how the endpoint should be exposed\
+                                \ on the network. \n - `public` means that the endpoint\
+                                \ will be exposed on the public network, typically\
+                                \ through a K8S ingress or an OpenShift route. \n\
+                                \ - `internal` means that the endpoint will be exposed\
+                                \ internally outside of the main workspace POD, typically\
+                                \ by K8S services, to be consumed by other elements\
+                                \ running on the same cloud internal network. \n -\
+                                \ `none` means that the endpoint will not be exposed\
+                                \ and will only be accessible inside the main workspace\
+                                \ POD, on a local address. \n Default value is `public`"
+                              enum:
+                                - public
+                                - internal
+                                - none
+                              type: string
+                            name:
+                              type: string
+                            path:
+                              description: Path of the endpoint URL
+                              type: string
+                            protocol:
+                              description: "Describes the application and transport\
+                                \ protocols of the traffic that will go through this\
+                                \ endpoint. \n - `http`: Endpoint will have `http`\
+                                \ traffic, typically on a TCP connection. It will\
+                                \ be automaticaly promoted to `https` when the `secure`\
+                                \ field is set to `true`. \n - `https`: Endpoint will\
+                                \ have `https` traffic, typically on a TCP connection.\
+                                \ \n - `ws`: Endpoint will have `ws` traffic, typically\
+                                \ on a TCP connection. It will be automaticaly promoted\
+                                \ to `wss` when the `secure` field is set to `true`.\
+                                \ \n - `wss`: Endpoint will have `wss` traffic, typically\
+                                \ on a TCP connection. \n - `tcp`: Endpoint will have\
+                                \ traffic on a TCP connection, without specifying\
+                                \ an application protocol. \n - `udp`: Endpoint will\
+                                \ have traffic on an UDP connection, without specifying\
+                                \ an application protocol. \n Default value is `http`"
+                              type: string
+                            secure:
+                              description: Describes whether the endpoint should be
+                                secured and protected by some authentication process
+                              type: boolean
+                            targetPort:
+                              type: integer
+                          required:
+                            - name
+                          type: object
+                        type: array
                       inlined:
                         description: Inlined manifest
                         type: string
@@ -498,6 +649,68 @@ spec:
                       reusing the OpenShift definitions used to deploy some runtime
                       components in production.
                     properties:
+                      endpoints:
+                        items:
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                type: string
+                              description: "Map of implementation-dependant string-based\
+                                \ free-form attributes. \n Examples of Che-specific\
+                                \ attributes: \n - cookiesAuthEnabled: \"true\" /\
+                                \ \"false\", \n - type: \"terminal\" / \"ide\" / \"\
+                                ide-dev\","
+                              type: object
+                            exposure:
+                              description: "Describes how the endpoint should be exposed\
+                                \ on the network. \n - `public` means that the endpoint\
+                                \ will be exposed on the public network, typically\
+                                \ through a K8S ingress or an OpenShift route. \n\
+                                \ - `internal` means that the endpoint will be exposed\
+                                \ internally outside of the main workspace POD, typically\
+                                \ by K8S services, to be consumed by other elements\
+                                \ running on the same cloud internal network. \n -\
+                                \ `none` means that the endpoint will not be exposed\
+                                \ and will only be accessible inside the main workspace\
+                                \ POD, on a local address. \n Default value is `public`"
+                              enum:
+                                - public
+                                - internal
+                                - none
+                              type: string
+                            name:
+                              type: string
+                            path:
+                              description: Path of the endpoint URL
+                              type: string
+                            protocol:
+                              description: "Describes the application and transport\
+                                \ protocols of the traffic that will go through this\
+                                \ endpoint. \n - `http`: Endpoint will have `http`\
+                                \ traffic, typically on a TCP connection. It will\
+                                \ be automaticaly promoted to `https` when the `secure`\
+                                \ field is set to `true`. \n - `https`: Endpoint will\
+                                \ have `https` traffic, typically on a TCP connection.\
+                                \ \n - `ws`: Endpoint will have `ws` traffic, typically\
+                                \ on a TCP connection. It will be automaticaly promoted\
+                                \ to `wss` when the `secure` field is set to `true`.\
+                                \ \n - `wss`: Endpoint will have `wss` traffic, typically\
+                                \ on a TCP connection. \n - `tcp`: Endpoint will have\
+                                \ traffic on a TCP connection, without specifying\
+                                \ an application protocol. \n - `udp`: Endpoint will\
+                                \ have traffic on an UDP connection, without specifying\
+                                \ an application protocol. \n Default value is `http`"
+                              type: string
+                            secure:
+                              description: Describes whether the endpoint should be
+                                secured and protected by some authentication process
+                              type: boolean
+                            targetPort:
+                              type: integer
+                          required:
+                            - name
+                          type: object
+                        type: array
                       inlined:
                         description: Inlined manifest
                         type: string
@@ -518,21 +731,77 @@ spec:
                       - name
                     type: object
                   plugin:
-                    description: Allows importing a plugin. Plugins are mainly imported
-                      devfiles that contribute components, commands and events as
-                      a consistent single unit. They are defined in either YAML files
-                      following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes
-                      Custom Resources
+                    description: "Allows importing a plugin. \n Plugins are mainly\
+                      \ imported devfiles that contribute components, commands and\
+                      \ events as a consistent single unit. They are defined in either\
+                      \ YAML files following the devfile syntax, or as `DevWorkspaceTemplate`\
+                      \ Kubernetes Custom Resources"
                     properties:
                       commands:
-                        description: Overrides of commands encapsulated in a plugin.
-                          Overriding is done using a strategic merge
+                        description: Overrides of commands encapsulated in a parent
+                          devfile or a plugin. Overriding is done using a strategic
+                          merge patch
                         items:
                           properties:
+                            apply:
+                              description: "Command that consists in applying a given\
+                                \ component definition, typically bound to a workspace\
+                                \ event. \n For example, when an `apply` command is\
+                                \ bound to a `preStart` event, and references a `container`\
+                                \ component, it will start the container as a K8S\
+                                \ initContainer in the workspace POD, unless the component\
+                                \ has its `dedicatedPod` field set to `true`. \n When\
+                                \ no `apply` command exist for a given component,\
+                                \ it is assumed the component will be applied at workspace\
+                                \ start by default."
+                              properties:
+                                attributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: Optional map of free-form additional
+                                    command attributes
+                                  type: object
+                                component:
+                                  description: Describes component that will be applied
+                                  type: string
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                        - build
+                                        - run
+                                        - test
+                                        - debug
+                                      type: string
+                                  required:
+                                    - kind
+                                  type: object
+                                id:
+                                  description: Mandatory identifier that allows referencing
+                                    this command in composite commands, from a parent,
+                                    or in events.
+                                  type: string
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                              required:
+                                - id
+                              type: object
                             commandType:
                               description: Type of workspace command
                               enum:
                                 - Exec
+                                - Apply
                                 - VscodeTask
                                 - VscodeLaunch
                                 - Composite
@@ -576,8 +845,8 @@ spec:
                                   type: object
                                 id:
                                   description: Mandatory identifier that allows referencing
-                                    this command in composite commands, or from a
-                                    parent, or in events.
+                                    this command in composite commands, from a parent,
+                                    or in events.
                                   type: string
                                 label:
                                   description: Optional label that provides a label
@@ -636,8 +905,8 @@ spec:
                                   type: object
                                 id:
                                   description: Mandatory identifier that allows referencing
-                                    this command in composite commands, or from a
-                                    parent, or in events.
+                                    this command in composite commands, from a parent,
+                                    or in events.
                                   type: string
                                 label:
                                   description: Optional label that provides a label
@@ -650,7 +919,8 @@ spec:
                                 - id
                               type: object
                             exec:
-                              description: CLI Command executed in a component container
+                              description: CLI Command executed in an existing component
+                                container
                               properties:
                                 attributes:
                                   additionalProperties:
@@ -659,7 +929,13 @@ spec:
                                     command attributes
                                   type: object
                                 commandLine:
-                                  description: The actual command-line string
+                                  description: "The actual command-line string \n\
+                                    \ Special variables that can be used: \n  - `$PROJECTS_ROOT`:\
+                                    \ A path where projects sources are mounted \n\
+                                    \  - `$PROJECT_SOURCE`: A path to a project source\
+                                    \ ($PROJECTS_ROOT/<project-name>). If there are\
+                                    \ multiple projects, this will point to the directory\
+                                    \ of the first one."
                                   type: string
                                 component:
                                   description: Describes component to which given
@@ -699,10 +975,17 @@ spec:
                                   required:
                                     - kind
                                   type: object
+                                hotReloadCapable:
+                                  description: "Whether the command is capable to\
+                                    \ reload itself when source code changes. If set\
+                                    \ to `true` the command won't be restarted and\
+                                    \ it is expected to handle file changes on its\
+                                    \ own. \n Default value is `false`"
+                                  type: boolean
                                 id:
                                   description: Mandatory identifier that allows referencing
-                                    this command in composite commands, or from a
-                                    parent, or in events.
+                                    this command in composite commands, from a parent,
+                                    or in events.
                                   type: string
                                 label:
                                   description: Optional label that provides a label
@@ -710,8 +993,13 @@ spec:
                                     for example
                                   type: string
                                 workingDir:
-                                  description: Working directory where the command
-                                    should be executed
+                                  description: "Working directory where the command\
+                                    \ should be executed \n Special variables that\
+                                    \ can be used: \n  - `${PROJECTS_ROOT}`: A path\
+                                    \ where projects sources are mounted \n  - `${PROJECT_SOURCE}`:\
+                                    \ A path to a project source (${PROJECTS_ROOT}/<project-name>).\
+                                    \ If there are multiple projects, this will point\
+                                    \ to the directory of the first one."
                                   type: string
                               required:
                                 - id
@@ -748,8 +1036,8 @@ spec:
                                   type: object
                                 id:
                                   description: Mandatory identifier that allows referencing
-                                    this command in composite commands, or from a
-                                    parent, or in events.
+                                    this command in composite commands, from a parent,
+                                    or in events.
                                   type: string
                                 inlined:
                                   description: Inlined content of the VsCode configuration
@@ -800,8 +1088,8 @@ spec:
                                   type: object
                                 id:
                                   description: Mandatory identifier that allows referencing
-                                    this command in composite commands, or from a
-                                    parent, or in events.
+                                    this command in composite commands, from a parent,
+                                    or in events.
                                   type: string
                                 inlined:
                                   description: Inlined content of the VsCode configuration
@@ -824,11 +1112,12 @@ spec:
                         type: array
                       components:
                         description: Overrides of components encapsulated in a plugin.
-                          Overriding is done using a strategic merge
+                          Overriding is done using a strategic merge patch. A plugin
+                          cannot override embedded plugin components.
                         items:
                           properties:
                             componentType:
-                              description: Type of component override
+                              description: Type of component override for a plugin
                               enum:
                                 - Container
                                 - Kubernetes
@@ -837,64 +1126,98 @@ spec:
                               type: string
                             container:
                               description: Configuration overriding for a Container
-                                component
+                                component in a plugin
                               properties:
                                 args:
-                                  description: The arguments to supply to the command
-                                    running the dockerimage component. The arguments
-                                    are supplied either to the default command provided
-                                    in the image or to the overridden command. Defaults
-                                    to an empty array, meaning use whatever is defined
-                                    in the image.
+                                  description: "The arguments to supply to the command\
+                                    \ running the dockerimage component. The arguments\
+                                    \ are supplied either to the default command provided\
+                                    \ in the image or to the overridden command. \n\
+                                    \ Defaults to an empty array, meaning use whatever\
+                                    \ is defined in the image."
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: The command to run in the dockerimage
-                                    component instead of the default one provided
-                                    in the image. Defaults to an empty array, meaning
-                                    use whatever is defined in the image.
+                                  description: "The command to run in the dockerimage\
+                                    \ component instead of the default one provided\
+                                    \ in the image. \n Defaults to an empty array,\
+                                    \ meaning use whatever is defined in the image."
                                   items:
                                     type: string
                                   type: array
+                                dedicatedPod:
+                                  description: "Specify if a container should run\
+                                    \ in its own separated pod, instead of running\
+                                    \ as part of the main development environment\
+                                    \ pod. \n Default value is `false`"
+                                  type: boolean
                                 endpoints:
                                   items:
                                     properties:
                                       attributes:
                                         additionalProperties:
                                           type: string
+                                        description: "Map of implementation-dependant\
+                                          \ string-based free-form attributes. \n\
+                                          \ Examples of Che-specific attributes: \n\
+                                          \ - cookiesAuthEnabled: \"true\" / \"false\"\
+                                          , \n - type: \"terminal\" / \"ide\" / \"\
+                                          ide-dev\","
                                         type: object
-                                      configuration:
-                                        properties:
-                                          cookiesAuthEnabled:
-                                            type: boolean
-                                          discoverable:
-                                            type: boolean
-                                          path:
-                                            type: string
-                                          protocol:
-                                            description: The is the low-level protocol
-                                              of traffic coming through this endpoint.
-                                              Default value is "tcp"
-                                            type: string
-                                          public:
-                                            type: boolean
-                                          scheme:
-                                            description: The is the URL scheme to
-                                              use when accessing the endpoint. Default
-                                              value is "http"
-                                            type: string
-                                          secure:
-                                            type: boolean
-                                          type:
-                                            enum:
-                                              - ide
-                                              - terminal
-                                              - ide-dev
-                                            type: string
-                                        type: object
+                                      exposure:
+                                        description: "Describes how the endpoint should\
+                                          \ be exposed on the network. \n - `public`\
+                                          \ means that the endpoint will be exposed\
+                                          \ on the public network, typically through\
+                                          \ a K8S ingress or an OpenShift route. \n\
+                                          \ - `internal` means that the endpoint will\
+                                          \ be exposed internally outside of the main\
+                                          \ workspace POD, typically by K8S services,\
+                                          \ to be consumed by other elements running\
+                                          \ on the same cloud internal network. \n\
+                                          \ - `none` means that the endpoint will\
+                                          \ not be exposed and will only be accessible\
+                                          \ inside the main workspace POD, on a local\
+                                          \ address. \n Default value is `public`"
+                                        enum:
+                                          - public
+                                          - internal
+                                          - none
+                                        type: string
                                       name:
                                         type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        description: "Describes the application and\
+                                          \ transport protocols of the traffic that\
+                                          \ will go through this endpoint. \n - `http`:\
+                                          \ Endpoint will have `http` traffic, typically\
+                                          \ on a TCP connection. It will be automaticaly\
+                                          \ promoted to `https` when the `secure`\
+                                          \ field is set to `true`. \n - `https`:\
+                                          \ Endpoint will have `https` traffic, typically\
+                                          \ on a TCP connection. \n - `ws`: Endpoint\
+                                          \ will have `ws` traffic, typically on a\
+                                          \ TCP connection. It will be automaticaly\
+                                          \ promoted to `wss` when the `secure` field\
+                                          \ is set to `true`. \n - `wss`: Endpoint\
+                                          \ will have `wss` traffic, typically on\
+                                          \ a TCP connection. \n - `tcp`: Endpoint\
+                                          \ will have traffic on a TCP connection,\
+                                          \ without specifying an application protocol.\
+                                          \ \n - `udp`: Endpoint will have traffic\
+                                          \ on an UDP connection, without specifying\
+                                          \ an application protocol. \n Default value\
+                                          \ is `http`"
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process
+                                        type: boolean
                                       targetPort:
                                         type: integer
                                     required:
@@ -940,11 +1263,9 @@ spec:
                                       name:
                                         description: The volume mount name is the
                                           name of an existing `Volume` component.
-                                          If no corresponding `Volume` component exist
-                                          it is implicitly added. If several containers
-                                          mount the same volume name then they will
-                                          reuse the same volume and will be able to
-                                          access to the same files.
+                                          If several containers mount the same volume
+                                          name then they will reuse the same volume
+                                          and will be able to access to the same files.
                                         type: string
                                       path:
                                         description: The path in the component container
@@ -961,8 +1282,80 @@ spec:
                               type: object
                             kubernetes:
                               description: Configuration overriding for a Kubernetes
-                                component
+                                component in a plugin
                               properties:
+                                endpoints:
+                                  items:
+                                    properties:
+                                      attributes:
+                                        additionalProperties:
+                                          type: string
+                                        description: "Map of implementation-dependant\
+                                          \ string-based free-form attributes. \n\
+                                          \ Examples of Che-specific attributes: \n\
+                                          \ - cookiesAuthEnabled: \"true\" / \"false\"\
+                                          , \n - type: \"terminal\" / \"ide\" / \"\
+                                          ide-dev\","
+                                        type: object
+                                      exposure:
+                                        description: "Describes how the endpoint should\
+                                          \ be exposed on the network. \n - `public`\
+                                          \ means that the endpoint will be exposed\
+                                          \ on the public network, typically through\
+                                          \ a K8S ingress or an OpenShift route. \n\
+                                          \ - `internal` means that the endpoint will\
+                                          \ be exposed internally outside of the main\
+                                          \ workspace POD, typically by K8S services,\
+                                          \ to be consumed by other elements running\
+                                          \ on the same cloud internal network. \n\
+                                          \ - `none` means that the endpoint will\
+                                          \ not be exposed and will only be accessible\
+                                          \ inside the main workspace POD, on a local\
+                                          \ address. \n Default value is `public`"
+                                        enum:
+                                          - public
+                                          - internal
+                                          - none
+                                        type: string
+                                      name:
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        description: "Describes the application and\
+                                          \ transport protocols of the traffic that\
+                                          \ will go through this endpoint. \n - `http`:\
+                                          \ Endpoint will have `http` traffic, typically\
+                                          \ on a TCP connection. It will be automaticaly\
+                                          \ promoted to `https` when the `secure`\
+                                          \ field is set to `true`. \n - `https`:\
+                                          \ Endpoint will have `https` traffic, typically\
+                                          \ on a TCP connection. \n - `ws`: Endpoint\
+                                          \ will have `ws` traffic, typically on a\
+                                          \ TCP connection. It will be automaticaly\
+                                          \ promoted to `wss` when the `secure` field\
+                                          \ is set to `true`. \n - `wss`: Endpoint\
+                                          \ will have `wss` traffic, typically on\
+                                          \ a TCP connection. \n - `tcp`: Endpoint\
+                                          \ will have traffic on a TCP connection,\
+                                          \ without specifying an application protocol.\
+                                          \ \n - `udp`: Endpoint will have traffic\
+                                          \ on an UDP connection, without specifying\
+                                          \ an application protocol. \n Default value\
+                                          \ is `http`"
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process
+                                        type: boolean
+                                      targetPort:
+                                        type: integer
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
                                 inlined:
                                   description: Inlined manifest
                                   type: string
@@ -984,8 +1377,80 @@ spec:
                               type: object
                             openshift:
                               description: Configuration overriding for an OpenShift
-                                component
+                                component in a plugin
                               properties:
+                                endpoints:
+                                  items:
+                                    properties:
+                                      attributes:
+                                        additionalProperties:
+                                          type: string
+                                        description: "Map of implementation-dependant\
+                                          \ string-based free-form attributes. \n\
+                                          \ Examples of Che-specific attributes: \n\
+                                          \ - cookiesAuthEnabled: \"true\" / \"false\"\
+                                          , \n - type: \"terminal\" / \"ide\" / \"\
+                                          ide-dev\","
+                                        type: object
+                                      exposure:
+                                        description: "Describes how the endpoint should\
+                                          \ be exposed on the network. \n - `public`\
+                                          \ means that the endpoint will be exposed\
+                                          \ on the public network, typically through\
+                                          \ a K8S ingress or an OpenShift route. \n\
+                                          \ - `internal` means that the endpoint will\
+                                          \ be exposed internally outside of the main\
+                                          \ workspace POD, typically by K8S services,\
+                                          \ to be consumed by other elements running\
+                                          \ on the same cloud internal network. \n\
+                                          \ - `none` means that the endpoint will\
+                                          \ not be exposed and will only be accessible\
+                                          \ inside the main workspace POD, on a local\
+                                          \ address. \n Default value is `public`"
+                                        enum:
+                                          - public
+                                          - internal
+                                          - none
+                                        type: string
+                                      name:
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        description: "Describes the application and\
+                                          \ transport protocols of the traffic that\
+                                          \ will go through this endpoint. \n - `http`:\
+                                          \ Endpoint will have `http` traffic, typically\
+                                          \ on a TCP connection. It will be automaticaly\
+                                          \ promoted to `https` when the `secure`\
+                                          \ field is set to `true`. \n - `https`:\
+                                          \ Endpoint will have `https` traffic, typically\
+                                          \ on a TCP connection. \n - `ws`: Endpoint\
+                                          \ will have `ws` traffic, typically on a\
+                                          \ TCP connection. It will be automaticaly\
+                                          \ promoted to `wss` when the `secure` field\
+                                          \ is set to `true`. \n - `wss`: Endpoint\
+                                          \ will have `wss` traffic, typically on\
+                                          \ a TCP connection. \n - `tcp`: Endpoint\
+                                          \ will have traffic on a TCP connection,\
+                                          \ without specifying an application protocol.\
+                                          \ \n - `udp`: Endpoint will have traffic\
+                                          \ on an UDP connection, without specifying\
+                                          \ an application protocol. \n Default value\
+                                          \ is `http`"
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process
+                                        type: boolean
+                                      targetPort:
+                                        type: integer
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
                                 inlined:
                                   description: Inlined manifest
                                   type: string
@@ -1007,6 +1472,7 @@ spec:
                               type: object
                             volume:
                               description: Configuration overriding for a Volume component
+                                in a plugin
                               properties:
                                 name:
                                   description: Mandatory name that allows referencing
@@ -1150,37 +1616,56 @@ spec:
                             attributes:
                               additionalProperties:
                                 type: string
+                              description: "Map of implementation-dependant string-based\
+                                \ free-form attributes. \n Examples of Che-specific\
+                                \ attributes: \n - cookiesAuthEnabled: \"true\" /\
+                                \ \"false\", \n - type: \"terminal\" / \"ide\" / \"\
+                                ide-dev\","
                               type: object
-                            configuration:
-                              properties:
-                                cookiesAuthEnabled:
-                                  type: boolean
-                                discoverable:
-                                  type: boolean
-                                path:
-                                  type: string
-                                protocol:
-                                  description: The is the low-level protocol of traffic
-                                    coming through this endpoint. Default value is
-                                    "tcp"
-                                  type: string
-                                public:
-                                  type: boolean
-                                scheme:
-                                  description: The is the URL scheme to use when accessing
-                                    the endpoint. Default value is "http"
-                                  type: string
-                                secure:
-                                  type: boolean
-                                type:
-                                  enum:
-                                    - ide
-                                    - terminal
-                                    - ide-dev
-                                  type: string
-                              type: object
+                            exposure:
+                              description: "Describes how the endpoint should be exposed\
+                                \ on the network. \n - `public` means that the endpoint\
+                                \ will be exposed on the public network, typically\
+                                \ through a K8S ingress or an OpenShift route. \n\
+                                \ - `internal` means that the endpoint will be exposed\
+                                \ internally outside of the main workspace POD, typically\
+                                \ by K8S services, to be consumed by other elements\
+                                \ running on the same cloud internal network. \n -\
+                                \ `none` means that the endpoint will not be exposed\
+                                \ and will only be accessible inside the main workspace\
+                                \ POD, on a local address. \n Default value is `public`"
+                              enum:
+                                - public
+                                - internal
+                                - none
+                              type: string
                             name:
                               type: string
+                            path:
+                              description: Path of the endpoint URL
+                              type: string
+                            protocol:
+                              description: "Describes the application and transport\
+                                \ protocols of the traffic that will go through this\
+                                \ endpoint. \n - `http`: Endpoint will have `http`\
+                                \ traffic, typically on a TCP connection. It will\
+                                \ be automaticaly promoted to `https` when the `secure`\
+                                \ field is set to `true`. \n - `https`: Endpoint will\
+                                \ have `https` traffic, typically on a TCP connection.\
+                                \ \n - `ws`: Endpoint will have `ws` traffic, typically\
+                                \ on a TCP connection. It will be automaticaly promoted\
+                                \ to `wss` when the `secure` field is set to `true`.\
+                                \ \n - `wss`: Endpoint will have `wss` traffic, typically\
+                                \ on a TCP connection. \n - `tcp`: Endpoint will have\
+                                \ traffic on a TCP connection, without specifying\
+                                \ an application protocol. \n - `udp`: Endpoint will\
+                                \ have traffic on an UDP connection, without specifying\
+                                \ an application protocol. \n Default value is `http`"
+                              type: string
+                            secure:
+                              description: Describes whether the endpoint should be
+                                secured and protected by some authentication process
+                              type: boolean
                             targetPort:
                               type: integer
                           required:

--- a/manifests/controller.devfile.io_workspaceroutings_crd.yaml
+++ b/manifests/controller.devfile.io_workspaceroutings_crd.yaml
@@ -38,36 +38,53 @@ spec:
                     attributes:
                       additionalProperties:
                         type: string
+                      description: "Map of implementation-dependant string-based free-form\
+                        \ attributes. \n Examples of Che-specific attributes: \n -\
+                        \ cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"\
+                        terminal\" / \"ide\" / \"ide-dev\","
                       type: object
-                    configuration:
-                      properties:
-                        cookiesAuthEnabled:
-                          type: boolean
-                        discoverable:
-                          type: boolean
-                        path:
-                          type: string
-                        protocol:
-                          description: The is the low-level protocol of traffic coming
-                            through this endpoint. Default value is "tcp"
-                          type: string
-                        public:
-                          type: boolean
-                        scheme:
-                          description: The is the URL scheme to use when accessing
-                            the endpoint. Default value is "http"
-                          type: string
-                        secure:
-                          type: boolean
-                        type:
-                          enum:
-                            - ide
-                            - terminal
-                            - ide-dev
-                          type: string
-                      type: object
+                    exposure:
+                      description: "Describes how the endpoint should be exposed on\
+                        \ the network. \n - `public` means that the endpoint will\
+                        \ be exposed on the public network, typically through a K8S\
+                        \ ingress or an OpenShift route. \n - `internal` means that\
+                        \ the endpoint will be exposed internally outside of the main\
+                        \ workspace POD, typically by K8S services, to be consumed\
+                        \ by other elements running on the same cloud internal network.\
+                        \ \n - `none` means that the endpoint will not be exposed\
+                        \ and will only be accessible inside the main workspace POD,\
+                        \ on a local address. \n Default value is `public`"
+                      enum:
+                        - public
+                        - internal
+                        - none
+                      type: string
                     name:
                       type: string
+                    path:
+                      description: Path of the endpoint URL
+                      type: string
+                    protocol:
+                      description: "Describes the application and transport protocols\
+                        \ of the traffic that will go through this endpoint. \n -\
+                        \ `http`: Endpoint will have `http` traffic, typically on\
+                        \ a TCP connection. It will be automaticaly promoted to `https`\
+                        \ when the `secure` field is set to `true`. \n - `https`:\
+                        \ Endpoint will have `https` traffic, typically on a TCP connection.\
+                        \ \n - `ws`: Endpoint will have `ws` traffic, typically on\
+                        \ a TCP connection. It will be automaticaly promoted to `wss`\
+                        \ when the `secure` field is set to `true`. \n - `wss`: Endpoint\
+                        \ will have `wss` traffic, typically on a TCP connection.\
+                        \ \n - `tcp`: Endpoint will have traffic on a TCP connection,\
+                        \ without specifying an application protocol. \n - `udp`:\
+                        \ Endpoint will have traffic on an UDP connection, without\
+                        \ specifying an application protocol. \n Default value is\
+                        \ `http`"
+                      type: string
+                    secure:
+                      description: Describes whether the endpoint should be secured
+                        and protected by some authentication process
+                      type: boolean
                     targetPort:
                       type: integer
                   required:

--- a/manifests/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/manifests/workspace.devfile.io_devworkspaces_crd.yaml
@@ -232,7 +232,12 @@ spec:
                               attributes
                             type: object
                           commandLine:
-                            description: The actual command-line string
+                            description: "The actual command-line string \n Special
+                              variables that can be used: \n  - `$PROJECTS_ROOT`:
+                              A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                              A path to a project source ($PROJECTS_ROOT/<project-name>).
+                              If there are multiple projects, this will point to the
+                              directory of the first one."
                             type: string
                           component:
                             description: Describes component to which given action
@@ -270,6 +275,12 @@ spec:
                             required:
                             - kind
                             type: object
+                          hotReloadCapable:
+                            description: "Whether the command is capable to reload
+                              itself when source code changes. If set to `true` the
+                              command won't be restarted and it is expected to handle
+                              file changes on its own. \n Default value is `false`"
+                            type: boolean
                           id:
                             description: Mandatory identifier that allows referencing
                               this command in composite commands, from a parent, or
@@ -280,8 +291,13 @@ spec:
                               this command to be used in Editor UI menus for example
                             type: string
                           workingDir:
-                            description: Working directory where the command should
-                              be executed
+                            description: "Working directory where the command should
+                              be executed \n Special variables that can be used: \n
+                              \ - `${PROJECTS_ROOT}`: A path where projects sources
+                              are mounted \n  - `${PROJECT_SOURCE}`: A path to a project
+                              source (${PROJECTS_ROOT}/<project-name>). If there are
+                              multiple projects, this will point to the directory
+                              of the first one."
                             type: string
                         required:
                         - id
@@ -763,8 +779,9 @@ spec:
                           Kubernetes Custom Resources"
                         properties:
                           commands:
-                            description: Overrides of commands encapsulated in a plugin.
-                              Overriding is done using a strategic merge
+                            description: Overrides of commands encapsulated in a parent
+                              devfile or a plugin. Overriding is done using a strategic
+                              merge patch
                             items:
                               properties:
                                 apply:
@@ -955,7 +972,13 @@ spec:
                                         command attributes
                                       type: object
                                     commandLine:
-                                      description: The actual command-line string
+                                      description: "The actual command-line string
+                                        \n Special variables that can be used: \n
+                                        \ - `$PROJECTS_ROOT`: A path where projects
+                                        sources are mounted \n  - `$PROJECT_SOURCE`:
+                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                        If there are multiple projects, this will
+                                        point to the directory of the first one."
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -995,6 +1018,13 @@ spec:
                                       required:
                                       - kind
                                       type: object
+                                    hotReloadCapable:
+                                      description: "Whether the command is capable
+                                        to reload itself when source code changes.
+                                        If set to `true` the command won't be restarted
+                                        and it is expected to handle file changes
+                                        on its own. \n Default value is `false`"
+                                      type: boolean
                                     id:
                                       description: Mandatory identifier that allows
                                         referencing this command in composite commands,
@@ -1006,8 +1036,13 @@ spec:
                                         UI menus for example
                                       type: string
                                     workingDir:
-                                      description: Working directory where the command
-                                        should be executed
+                                      description: "Working directory where the command
+                                        should be executed \n Special variables that
+                                        can be used: \n  - `${PROJECTS_ROOT}`: A path
+                                        where projects sources are mounted \n  - `${PROJECT_SOURCE}`:
+                                        A path to a project source (${PROJECTS_ROOT}/<project-name>).
+                                        If there are multiple projects, this will
+                                        point to the directory of the first one."
                                       type: string
                                   required:
                                   - id
@@ -1122,11 +1157,12 @@ spec:
                             type: array
                           components:
                             description: Overrides of components encapsulated in a
-                              plugin. Overriding is done using a strategic merge
+                              plugin. Overriding is done using a strategic merge patch.
+                              A plugin cannot override embedded plugin components.
                             items:
                               properties:
                                 componentType:
-                                  description: Type of component override
+                                  description: Type of component override for a plugin
                                   enum:
                                   - Container
                                   - Kubernetes
@@ -1135,7 +1171,7 @@ spec:
                                   type: string
                                 container:
                                   description: Configuration overriding for a Container
-                                    component
+                                    component in a plugin
                                   properties:
                                     args:
                                       description: "The arguments to supply to the
@@ -1294,7 +1330,7 @@ spec:
                                   type: object
                                 kubernetes:
                                   description: Configuration overriding for a Kubernetes
-                                    component
+                                    component in a plugin
                                   properties:
                                     endpoints:
                                       items:
@@ -1392,7 +1428,7 @@ spec:
                                   type: object
                                 openshift:
                                   description: Configuration overriding for an OpenShift
-                                    component
+                                    component in a plugin
                                   properties:
                                     endpoints:
                                       items:
@@ -1490,7 +1526,7 @@ spec:
                                   type: object
                                 volume:
                                   description: Configuration overriding for a Volume
-                                    component
+                                    component in a plugin
                                   properties:
                                     name:
                                       description: Mandatory name that allows referencing
@@ -1594,7 +1630,9 @@ spec:
                   description: Parent workspace template
                   properties:
                     commands:
-                      description: Predefined, ready-to-use, workspace-related commands
+                      description: Overrides of commands encapsulated in a parent
+                        devfile or a plugin. Overriding is done using a strategic
+                        merge patch
                       items:
                         properties:
                           apply:
@@ -1782,7 +1820,12 @@ spec:
                                   command attributes
                                 type: object
                               commandLine:
-                                description: The actual command-line string
+                                description: "The actual command-line string \n Special
+                                  variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                  A path where projects sources are mounted \n  -
+                                  `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one."
                                 type: string
                               component:
                                 description: Describes component to which given action
@@ -1822,6 +1865,13 @@ spec:
                                 required:
                                 - kind
                                 type: object
+                              hotReloadCapable:
+                                description: "Whether the command is capable to reload
+                                  itself when source code changes. If set to `true`
+                                  the command won't be restarted and it is expected
+                                  to handle file changes on its own. \n Default value
+                                  is `false`"
+                                type: boolean
                               id:
                                 description: Mandatory identifier that allows referencing
                                   this command in composite commands, from a parent,
@@ -1833,8 +1883,13 @@ spec:
                                   example
                                 type: string
                               workingDir:
-                                description: Working directory where the command should
-                                  be executed
+                                description: "Working directory where the command
+                                  should be executed \n Special variables that can
+                                  be used: \n  - `${PROJECTS_ROOT}`: A path where
+                                  projects sources are mounted \n  - `${PROJECT_SOURCE}`:
+                                  A path to a project source (${PROJECTS_ROOT}/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one."
                                 type: string
                             required:
                             - id
@@ -1946,8 +2001,8 @@ spec:
                         type: object
                       type: array
                     components:
-                      description: List of the workspace components, such as editor
-                        and plugins, user-provided containers, or other types of components
+                      description: Overrides of components encapsulated in a parent
+                        devfile. Overriding is done using a strategic merge patch
                       items:
                         properties:
                           componentType:
@@ -2333,7 +2388,8 @@ spec:
                             properties:
                               commands:
                                 description: Overrides of commands encapsulated in
-                                  a plugin. Overriding is done using a strategic merge
+                                  a parent devfile or a plugin. Overriding is done
+                                  using a strategic merge patch
                                 items:
                                   properties:
                                     apply:
@@ -2526,7 +2582,13 @@ spec:
                                             command attributes
                                           type: object
                                         commandLine:
-                                          description: The actual command-line string
+                                          description: "The actual command-line string
+                                            \n Special variables that can be used:
+                                            \n  - `$PROJECTS_ROOT`: A path where projects
+                                            sources are mounted \n  - `$PROJECT_SOURCE`:
+                                            A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                            If there are multiple projects, this will
+                                            point to the directory of the first one."
                                           type: string
                                         component:
                                           description: Describes component to which
@@ -2567,6 +2629,14 @@ spec:
                                           required:
                                           - kind
                                           type: object
+                                        hotReloadCapable:
+                                          description: "Whether the command is capable
+                                            to reload itself when source code changes.
+                                            If set to `true` the command won't be
+                                            restarted and it is expected to handle
+                                            file changes on its own. \n Default value
+                                            is `false`"
+                                          type: boolean
                                         id:
                                           description: Mandatory identifier that allows
                                             referencing this command in composite
@@ -2578,8 +2648,14 @@ spec:
                                             Editor UI menus for example
                                           type: string
                                         workingDir:
-                                          description: Working directory where the
-                                            command should be executed
+                                          description: "Working directory where the
+                                            command should be executed \n Special
+                                            variables that can be used: \n  - `${PROJECTS_ROOT}`:
+                                            A path where projects sources are mounted
+                                            \n  - `${PROJECT_SOURCE}`: A path to a
+                                            project source (${PROJECTS_ROOT}/<project-name>).
+                                            If there are multiple projects, this will
+                                            point to the directory of the first one."
                                           type: string
                                       required:
                                       - id
@@ -2697,11 +2773,13 @@ spec:
                               components:
                                 description: Overrides of components encapsulated
                                   in a plugin. Overriding is done using a strategic
-                                  merge
+                                  merge patch. A plugin cannot override embedded plugin
+                                  components.
                                 items:
                                   properties:
                                     componentType:
-                                      description: Type of component override
+                                      description: Type of component override for
+                                        a plugin
                                       enum:
                                       - Container
                                       - Kubernetes
@@ -2710,7 +2788,7 @@ spec:
                                       type: string
                                     container:
                                       description: Configuration overriding for a
-                                        Container component
+                                        Container component in a plugin
                                       properties:
                                         args:
                                           description: "The arguments to supply to
@@ -2878,7 +2956,7 @@ spec:
                                       type: object
                                     kubernetes:
                                       description: Configuration overriding for a
-                                        Kubernetes component
+                                        Kubernetes component in a plugin
                                       properties:
                                         endpoints:
                                           items:
@@ -2982,7 +3060,7 @@ spec:
                                       type: object
                                     openshift:
                                       description: Configuration overriding for an
-                                        OpenShift component
+                                        OpenShift component in a plugin
                                       properties:
                                         endpoints:
                                           items:
@@ -3086,7 +3164,7 @@ spec:
                                       type: object
                                     volume:
                                       description: Configuration overriding for a
-                                        Volume component
+                                        Volume component in a plugin
                                       properties:
                                         name:
                                           description: Mandatory name that allows
@@ -3153,41 +3231,6 @@ spec:
                             type: object
                         type: object
                       type: array
-                    events:
-                      description: Bindings of commands to events. Each command is
-                        referred-to by its name.
-                      properties:
-                        postStart:
-                          description: Names of commands that should be executed after
-                            the workspace is completely started. In the case of Che-Theia,
-                            these commands should be executed after all plugins and
-                            extensions have started, including project cloning. This
-                            means that those commands are not triggered until the
-                            user opens the IDE in his browser.
-                          items:
-                            type: string
-                          type: array
-                        postStop:
-                          description: Names of commands that should be executed after
-                            stopping the workspace.
-                          items:
-                            type: string
-                          type: array
-                        preStart:
-                          description: Names of commands that should be executed before
-                            the workspace start. Kubernetes-wise, these commands would
-                            typically be executed in init containers of the workspace
-                            POD.
-                          items:
-                            type: string
-                          type: array
-                        preStop:
-                          description: Names of commands that should be executed before
-                            stopping the workspace.
-                          items:
-                            type: string
-                          type: array
-                      type: object
                     id:
                       description: Id in a registry that contains a Devfile yaml file
                       type: string
@@ -3210,8 +3253,8 @@ spec:
                       - name
                       type: object
                     projects:
-                      description: Projects worked on in the workspace, containing
-                        names and sources locations
+                      description: Overrides of projects encapsulated in a parent
+                        devfile. Overriding is done using a strategic merge patch.
                       items:
                         properties:
                           clonePath:
@@ -3238,41 +3281,65 @@ spec:
                           git:
                             description: Project's Git source
                             properties:
-                              branch:
-                                description: The branch to check
-                                type: string
-                              location:
-                                description: Project's source location address. Should
-                                  be URL for git and github located projects, or;
-                                  file:// for zip
-                                type: string
+                              checkoutFrom:
+                                description: Defines from what the project should
+                                  be checked out. Required if there are more than
+                                  one remote configured
+                                properties:
+                                  remote:
+                                    description: The remote name should be used as
+                                      init. Required if there are more than one remote
+                                      configured
+                                    type: string
+                                  revision:
+                                    description: The revision to checkout from. Should
+                                      be branch name, tag or commit id. Default branch
+                                      is used if missing or specified revision is
+                                      not found.
+                                    type: string
+                                type: object
+                              remotes:
+                                additionalProperties:
+                                  type: string
+                                description: The remotes map which should be initialized
+                                  in the git project. Must have at least one remote
+                                  configured
+                                type: object
                               sparseCheckoutDir:
                                 description: Part of project to populate in the working
                                   directory.
-                                type: string
-                              startPoint:
-                                description: The tag or commit id to reset the checked
-                                  out branch to
                                 type: string
                             type: object
                           github:
                             description: Project's GitHub source
                             properties:
-                              branch:
-                                description: The branch to check
-                                type: string
-                              location:
-                                description: Project's source location address. Should
-                                  be URL for git and github located projects, or;
-                                  file:// for zip
-                                type: string
+                              checkoutFrom:
+                                description: Defines from what the project should
+                                  be checked out. Required if there are more than
+                                  one remote configured
+                                properties:
+                                  remote:
+                                    description: The remote name should be used as
+                                      init. Required if there are more than one remote
+                                      configured
+                                    type: string
+                                  revision:
+                                    description: The revision to checkout from. Should
+                                      be branch name, tag or commit id. Default branch
+                                      is used if missing or specified revision is
+                                      not found.
+                                    type: string
+                                type: object
+                              remotes:
+                                additionalProperties:
+                                  type: string
+                                description: The remotes map which should be initialized
+                                  in the git project. Must have at least one remote
+                                  configured
+                                type: object
                               sparseCheckoutDir:
                                 description: Part of project to populate in the working
                                   directory.
-                                type: string
-                              startPoint:
-                                description: The tag or commit id to reset the checked
-                                  out branch to
                                 type: string
                             type: object
                           name:
@@ -3290,9 +3357,8 @@ spec:
                             description: Project's Zip source
                             properties:
                               location:
-                                description: Project's source location address. Should
-                                  be URL for git and github located projects, or;
-                                  file:// for zip
+                                description: Zip project's source location address.
+                                  Should be file path of the archive, e.g. file://$FILE_PATH
                                 type: string
                               sparseCheckoutDir:
                                 description: Part of project to populate in the working
@@ -3305,103 +3371,6 @@ spec:
                       type: array
                     registryUrl:
                       type: string
-                    starterProjects:
-                      description: StarterProjects is a project that can be used as
-                        a starting point when bootstrapping new projects
-                      items:
-                        properties:
-                          clonePath:
-                            description: Path relative to the root of the projects
-                              to which this project should be cloned into. This is
-                              a unix-style relative path (i.e. uses forward slashes).
-                              The path is invalid if it is absolute or tries to escape
-                              the project root through the usage of '..'. If not specified,
-                              defaults to the project name.
-                            type: string
-                          custom:
-                            description: Project's Custom source
-                            properties:
-                              embeddedResource:
-                                type: object
-                                x-kubernetes-embedded-resource: true
-                                x-kubernetes-preserve-unknown-fields: true
-                              projectSourceClass:
-                                type: string
-                            required:
-                            - embeddedResource
-                            - projectSourceClass
-                            type: object
-                          description:
-                            description: Description of a starter project
-                            type: string
-                          git:
-                            description: Project's Git source
-                            properties:
-                              branch:
-                                description: The branch to check
-                                type: string
-                              location:
-                                description: Project's source location address. Should
-                                  be URL for git and github located projects, or;
-                                  file:// for zip
-                                type: string
-                              sparseCheckoutDir:
-                                description: Part of project to populate in the working
-                                  directory.
-                                type: string
-                              startPoint:
-                                description: The tag or commit id to reset the checked
-                                  out branch to
-                                type: string
-                            type: object
-                          github:
-                            description: Project's GitHub source
-                            properties:
-                              branch:
-                                description: The branch to check
-                                type: string
-                              location:
-                                description: Project's source location address. Should
-                                  be URL for git and github located projects, or;
-                                  file:// for zip
-                                type: string
-                              sparseCheckoutDir:
-                                description: Part of project to populate in the working
-                                  directory.
-                                type: string
-                              startPoint:
-                                description: The tag or commit id to reset the checked
-                                  out branch to
-                                type: string
-                            type: object
-                          name:
-                            description: Project name
-                            type: string
-                          sourceType:
-                            description: Type of project source
-                            enum:
-                            - Git
-                            - Github
-                            - Zip
-                            - Custom
-                            type: string
-                          zip:
-                            description: Project's Zip source
-                            properties:
-                              location:
-                                description: Project's source location address. Should
-                                  be URL for git and github located projects, or;
-                                  file:// for zip
-                                type: string
-                              sparseCheckoutDir:
-                                description: Part of project to populate in the working
-                                  directory.
-                                type: string
-                            type: object
-                        required:
-                        - name
-                        type: object
-                      type: array
                     uri:
                       description: Uri of a Devfile yaml file
                       type: string
@@ -3435,41 +3404,59 @@ spec:
                       git:
                         description: Project's Git source
                         properties:
-                          branch:
-                            description: The branch to check
-                            type: string
-                          location:
-                            description: Project's source location address. Should
-                              be URL for git and github located projects, or; file://
-                              for zip
-                            type: string
+                          checkoutFrom:
+                            description: Defines from what the project should be checked
+                              out. Required if there are more than one remote configured
+                            properties:
+                              remote:
+                                description: The remote name should be used as init.
+                                  Required if there are more than one remote configured
+                                type: string
+                              revision:
+                                description: The revision to checkout from. Should
+                                  be branch name, tag or commit id. Default branch
+                                  is used if missing or specified revision is not
+                                  found.
+                                type: string
+                            type: object
+                          remotes:
+                            additionalProperties:
+                              type: string
+                            description: The remotes map which should be initialized
+                              in the git project. Must have at least one remote configured
+                            type: object
                           sparseCheckoutDir:
                             description: Part of project to populate in the working
                               directory.
-                            type: string
-                          startPoint:
-                            description: The tag or commit id to reset the checked
-                              out branch to
                             type: string
                         type: object
                       github:
                         description: Project's GitHub source
                         properties:
-                          branch:
-                            description: The branch to check
-                            type: string
-                          location:
-                            description: Project's source location address. Should
-                              be URL for git and github located projects, or; file://
-                              for zip
-                            type: string
+                          checkoutFrom:
+                            description: Defines from what the project should be checked
+                              out. Required if there are more than one remote configured
+                            properties:
+                              remote:
+                                description: The remote name should be used as init.
+                                  Required if there are more than one remote configured
+                                type: string
+                              revision:
+                                description: The revision to checkout from. Should
+                                  be branch name, tag or commit id. Default branch
+                                  is used if missing or specified revision is not
+                                  found.
+                                type: string
+                            type: object
+                          remotes:
+                            additionalProperties:
+                              type: string
+                            description: The remotes map which should be initialized
+                              in the git project. Must have at least one remote configured
+                            type: object
                           sparseCheckoutDir:
                             description: Part of project to populate in the working
                               directory.
-                            type: string
-                          startPoint:
-                            description: The tag or commit id to reset the checked
-                              out branch to
                             type: string
                         type: object
                       name:
@@ -3487,9 +3474,8 @@ spec:
                         description: Project's Zip source
                         properties:
                           location:
-                            description: Project's source location address. Should
-                              be URL for git and github located projects, or; file://
-                              for zip
+                            description: Zip project's source location address. Should
+                              be file path of the archive, e.g. file://$FILE_PATH
                             type: string
                           sparseCheckoutDir:
                             description: Part of project to populate in the working
@@ -3532,41 +3518,59 @@ spec:
                       git:
                         description: Project's Git source
                         properties:
-                          branch:
-                            description: The branch to check
-                            type: string
-                          location:
-                            description: Project's source location address. Should
-                              be URL for git and github located projects, or; file://
-                              for zip
-                            type: string
+                          checkoutFrom:
+                            description: Defines from what the project should be checked
+                              out. Required if there are more than one remote configured
+                            properties:
+                              remote:
+                                description: The remote name should be used as init.
+                                  Required if there are more than one remote configured
+                                type: string
+                              revision:
+                                description: The revision to checkout from. Should
+                                  be branch name, tag or commit id. Default branch
+                                  is used if missing or specified revision is not
+                                  found.
+                                type: string
+                            type: object
+                          remotes:
+                            additionalProperties:
+                              type: string
+                            description: The remotes map which should be initialized
+                              in the git project. Must have at least one remote configured
+                            type: object
                           sparseCheckoutDir:
                             description: Part of project to populate in the working
                               directory.
-                            type: string
-                          startPoint:
-                            description: The tag or commit id to reset the checked
-                              out branch to
                             type: string
                         type: object
                       github:
                         description: Project's GitHub source
                         properties:
-                          branch:
-                            description: The branch to check
-                            type: string
-                          location:
-                            description: Project's source location address. Should
-                              be URL for git and github located projects, or; file://
-                              for zip
-                            type: string
+                          checkoutFrom:
+                            description: Defines from what the project should be checked
+                              out. Required if there are more than one remote configured
+                            properties:
+                              remote:
+                                description: The remote name should be used as init.
+                                  Required if there are more than one remote configured
+                                type: string
+                              revision:
+                                description: The revision to checkout from. Should
+                                  be branch name, tag or commit id. Default branch
+                                  is used if missing or specified revision is not
+                                  found.
+                                type: string
+                            type: object
+                          remotes:
+                            additionalProperties:
+                              type: string
+                            description: The remotes map which should be initialized
+                              in the git project. Must have at least one remote configured
+                            type: object
                           sparseCheckoutDir:
                             description: Part of project to populate in the working
                               directory.
-                            type: string
-                          startPoint:
-                            description: The tag or commit id to reset the checked
-                              out branch to
                             type: string
                         type: object
                       name:
@@ -3584,9 +3588,8 @@ spec:
                         description: Project's Zip source
                         properties:
                           location:
-                            description: Project's source location address. Should
-                              be URL for git and github located projects, or; file://
-                              for zip
+                            description: Zip project's source location address. Should
+                              be file path of the archive, e.g. file://$FILE_PATH
                             type: string
                           sparseCheckoutDir:
                             description: Part of project to populate in the working

--- a/operator-subscription.yaml
+++ b/operator-subscription.yaml
@@ -7,6 +7,6 @@ spec:
   channel: alpha
   installPlanApproval: Automatic
   name: web-terminal
-  source: web-terminal-crd-registry
+  source: custom-web-terminal-catalog
   sourceNamespace: openshift-marketplace
   startingCSV: web-terminal.v1.0.0

--- a/update-dependencies.sh
+++ b/update-dependencies.sh
@@ -10,8 +10,10 @@ OPERATOR_DIR="${SCRIPT_DIR}/devworkspace-operator"
 CRDS_REPO="https://github.com/devfile/kubernetes-api.git"
 OPERATOR_REPO="https://github.com/devfile/devworkspace-operator.git"
 
-DEVWORKSPACE_API_VERSION=${DEVWORKSPACE_API_VERSION:-"master"}
-DEVWORKSPACE_OPERATOR_VERSION=${DEVWORKSPACE_OPERATOR_VERSION:-"master"}
+DEVWORKSPACE_API_VERSION=${DEVWORKSPACE_API_VERSION:-"v1alpha1"}
+# 400b4b7 is the https://github.com/devfile/devworkspace-operator/pull/146
+# but it's going to be replaced with master or even eventually with v1alpha1 devworkspace operator branch or tag
+DEVWORKSPACE_OPERATOR_VERSION=${DEVWORKSPACE_OPERATOR_VERSION:-"400b4b7"}
 
 COMBINED_DIR="${SCRIPT_DIR}/devworkspace-dependencies"
 
@@ -46,11 +48,14 @@ function update_dep() {
   git fetch --tags -p origin
   if git show-ref --verify "refs/tags/${version}" --quiet; then
     log 'Version is specified from tag'
-		git checkout "tags/${version}"
-	else
-		log 'Version is specified from branch'
-		git checkout "$version" && git reset --hard "origin/${version}"
-	fi
+    git checkout "tags/${version}"
+  elif -z $(git ls-remote --heads origin ${branch}); then
+    log 'Version is specified from branch'
+    git checkout "$version" && git reset --hard "origin/${version}"
+  else
+    log 'Version is specified from revision'
+    git checkout ${version}
+  fi
   popd > /dev/null
 }
 


### PR DESCRIPTION
### What does this PR do?
Port changes from v1.0.x and rename catalog source.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
```
make install
# make sure that Web Terminal is working for developer
make uninstall
make unregister_catalogsource
```