### PR TITLE
Check for skopeo not kubectl 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ ifndef INDEX_IMG
 endif
 
 _check_skopeo_installed:
-ifeq ($(shell command -v kubectl 2> /dev/null),)
+ifeq ($(shell command -v skopeo 2> /dev/null),)
 	$(error "skopeo is required for building and deploying bundle, but is not installed")
 endif
 


### PR DESCRIPTION
Signed-off-by: jpinkney <josh.pinkney@mail.utoronto.ca>

### What does this PR do?
PR fixes an issue where _check_skopeo_installed should use skopeo not kubectl

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
