### PR TITLE
Fix skopeo check in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ ifndef INDEX_IMG
 endif
 
 _check_skopeo_installed:
-ifeq ($(shell command -v kubectl 2> /dev/null),)
+ifeq ($(shell command -v skopeo 2> /dev/null),)
 	$(error "skopeo is required for building and deploying bundle, but is not installed")
 endif
 


### PR DESCRIPTION
### What does this PR do?
Fix the check for whether skopeo is installed; somehow it got switched to checking for kubectl instead

### What issues does this PR fix or reference?
Fixes #32 

