### PR TITLE
Remove com.redhat.delivery.appregistry from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ LABEL summary="$SUMMARY" \
       license="EPLv2" \
       maintainer="Joshua Pinkney <jpinkney@redhat.com>" \
       io.openshift.expose-services="" \
-      com.redhat.delivery.appregistry="false" \
       com.redhat.delivery.operator.bundle=true \
       com.redhat.openshift.versions="v4.5" \
       usage=""


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR removes the no longer needed com.redhat.delivery.appregistry label

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
