### PR TITLE
Remove replaces web-terminal.v1.0.0 since it won't be present in the index

### DIFF
--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -360,5 +360,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: web-terminal.v1.0.0
   version: 1.0.1


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR removes `replaces: web-terminal.v1.0.0` since 1.0.1 will be our first release

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
