### PR TITLE
Fix removing of WTO CSV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,9 @@ uninstall:
 	kubectl delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
 	kubectl delete components.controller.devfile.io --all-namespaces --all --wait
 	# 2. Uninstall the Operator
-	kubectl delete subscriptions.operators.coreos.com web-terminal -n openshift-operators
-	kubectl delete csv web-terminal.v1.0.2 -n openshift-operators
+	kubectl delete subscriptions.operators.coreos.com web-terminal -n openshift-operators --ignore-not-found
+	$(eval WTO_CSV := $(shell kubectl get csv -o=json | jq -r '[.items[] | select (.metadata.name | contains("web-terminal.v1"))][0].metadata.name'))
+	kubectl delete csv ${WTO_CSV} -n openshift-operators
 	# 3. Remove CRDs
 	kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io
 	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io
@@ -137,7 +138,8 @@ purge:
 	fi
 	# 2. Uninstall the Operator
 	kubectl delete subscriptions.operators.coreos.com web-terminal -n openshift-operators --ignore-not-found
-	kubectl delete csv web-terminal.v1.0.2 -n openshift-operators
+	$(eval WTO_CSV := $(shell kubectl get csv -o=json | jq -r '[.items[] | select (.metadata.name | contains("web-terminal.v1"))][0].metadata.name'))
+	kubectl delete csv ${WTO_CSV} -n openshift-operators || true
 	# 3. Remove CRDs
 	kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io --ignore-not-found
 	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io --ignore-not-found


### PR DESCRIPTION
### What does this PR do?
This PR fixes removing of WTO CSV.
Note that it's made against v1.0.x since we're going to deprecate master.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
1. `make install`
2. wait until WTO is installed
3. `make uninstall`
4. Make sure that WTO is not displayed as installed operator on Console.
