### PR TITLE
Add content sets for web terminal operator

### DIFF
--- a/content_sets.yml
+++ b/content_sets.yml
@@ -1,0 +1,16 @@
+# This is a file defining which content sets (yum repositories) are needed to
+# update content in this image. Data provided here helps determine which images
+# are vulnerable to specific CVEs. Generally you should only need to update this
+# file when:
+#    1. You start depending on a new product
+#    2. You are preparing new product release and your content sets will change
+#
+# See https://mojo.redhat.com/docs/DOC-1023066 for more information on
+# maintaining this file and the format and examples
+#
+# You should have one top level item for each architecture being built. Most
+# likely this will be x86_64 and ppc64le initially.
+---
+x86_64:
+- rhel-8-for-x86_64-baseos-rpms
+- rhel-8-for-x86_64-appstream-rpms

--- a/content_sets_rhel8.repo
+++ b/content_sets_rhel8.repo
@@ -1,0 +1,11 @@
+[rhel-8-for-appstream-rpms-pulp]
+name=rhel-8-appstream-rpms-pulp
+baseurl=http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel8/8/$basearch/appstream/os
+enabled=1
+gpgcheck=0
+
+[rhel-8-for-baseos-rpms-pulp]
+name=rhel-8-baseos-rpms-pulp
+baseurl=http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel8/8/$basearch/baseos/os
+enabled=1
+gpgcheck=0


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR adds in content sets that are needed for our next release of the web terminal operator. I'm not exactly sure how to verify it without throwing it into the pkg.devel repos. For now I've just copied them from web-terminal-tooling.

FWIW the previous cvp results are here: http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-product-test/web-terminal-operator-container-1.0.1-1/fd2f6fdf-ffad-4d04-94e3-6b08f092e044/sanity-tests-optional-results.json

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
