### PR TITLE
Re-add kerberos initialization in bootstrap-sync to fix syncing on CRW…

### DIFF
--- a/bootstrap-sync.sh
+++ b/bootstrap-sync.sh
@@ -23,6 +23,11 @@ User crw-build/codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com@REDH
 " > ~/.ssh/config
 chmod 600 ~/.ssh/config
 
+# initialize kerberos
+export KRB5CCNAME=/var/tmp/crw-build_ccache
+kinit "crw-build/codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com@REDHAT.COM" -kt "${CRW_KEYTAB}"
+klist # verify working
+
 sudo yum install skopeo podman -y
 
 #########################################################################


### PR DESCRIPTION
… jenkins

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
Currently source syncing is failing with `This system is not registered with an entitlement server. You can use subscription-manager to register.` which might be caused by kerberos not being initialized in the bootstrap-sync script. This causes the repos from dist-git to not clone. The failing job is https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/web-terminal-sync-web-terminal-tooling/4/console. Since we can't move to CPAAS jenkins yet this would just be a temp fix

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
