### PR TITLE
Parameritize SOURCE_BRANCH so that you can optionally choose the base…

### DIFF
--- a/controller.Jenkinsfile
+++ b/controller.Jenkinsfile
@@ -1,9 +1,10 @@
 #!/usr/bin/env groovy
 
+// PARAMETERS for this pipeline:
+// SOURCE_BRANCH = "v1.0.0-alphax" or "master" // branch of source repo from which to find and sync commits to pkgs.devel repo
+
 def SOURCE_REPO = 'devfile/devworkspace-operator' //source repo from which to find and sync commits to pkgs.devel repo
 def DWNSTM_REPO = 'containers/web-terminal' // dist-git repo to use as target for everything
-
-def SOURCE_BRANCH = 'master'         // target branch in GH repo, eg., master or v1.0.x
 def DWNSTM_BRANCH = 'web-terminal-1.0-rhel-8' // target branch in dist-git repo, eg., web-terminal-1.0-rhel-8
 
 def buildNode = 'rhel7-releng' // slave label

--- a/controller.Jenkinsfile
+++ b/controller.Jenkinsfile
@@ -2,10 +2,10 @@
 
 // PARAMETERS for this pipeline:
 // SOURCE_BRANCH = "v1.0.0-alphax" or "master" // branch of source repo from which to find and sync commits to pkgs.devel repo
+// DWNSTM_BRANCH = 'web-terminal-1.0-rhel-8' // target branch in dist-git repo, eg., web-terminal-1.0-rhel-8
 
 def SOURCE_REPO = 'devfile/devworkspace-operator' //source repo from which to find and sync commits to pkgs.devel repo
 def DWNSTM_REPO = 'containers/web-terminal' // dist-git repo to use as target for everything
-def DWNSTM_BRANCH = 'web-terminal-1.0-rhel-8' // target branch in dist-git repo, eg., web-terminal-1.0-rhel-8
 
 def buildNode = 'rhel7-releng' // slave label
 timeout(120) {

--- a/metadata.Jenkinsfile
+++ b/metadata.Jenkinsfile
@@ -1,10 +1,11 @@
 #!/usr/bin/env groovy
 
+// PARAMETERS for this pipeline:
+// SOURCE_BRANCH = "v1.0.x" // branch of source repo from which to find and sync commits to pkgs.devel repo
+// DWNSTM_BRANCH = 'web-terminal-1.0-rhel-8' // target branch in dist-git repo, eg., web-terminal-1.0-rhel-8
+
 def SOURCE_REPO = "redhat-developer/web-terminal-operator" //source repo from which to find and sync commits to pkgs.devel repo
 def DWNSTM_REPO = "containers/web-terminal-dev-operator-metadata" // dist-git repo to use as target for everything
-
-def SOURCE_BRANCH = "v1.0.x"         // target branch in GH repo, eg., master or v1.0.x
-def DWNSTM_BRANCH = "web-terminal-1.0-rhel-8" // target branch in dist-git repo, eg., web-terminal-1.0-rhel-8
 
 def buildNode = "rhel7-releng" // slave label
 timeout(120) {


### PR DESCRIPTION
… branch

### What does this PR do?
This PR makes it possible to change the branch you're going to sync from for devworkspace-operator by parameterizing SOURCE_BRANCH (essentially you will enter the branch you want to sync before you start a job). Since we are syncing v1.0.0-alphax branch to dist-git (and potentially other branches in this future?) it makes sense to make this a parameter

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>