### PR TITLE
Replace operator-sdk bundle create with docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,7 @@ gen_terminal_csv : update_dependencies
 build: _print_vars _check_imgs_env _check_skopeo_installed
 	@rm -rf ./generated
 	# Create the bundle and push it to a docker registry
-	operator-sdk bundle create $(BUNDLE_IMG) --channels alpha --package web-terminal --directory ./manifests --overwrite --output-dir generated
-	docker push $(BUNDLE_IMG)
+	docker build -f Dockerfile -t $(BUNDLE_IMG) .
 
 	BUNDLE_DIGEST=$$(skopeo inspect docker://$(BUNDLE_IMG) | jq -r '.Digest')
 	BUNDLE_IMG=$(BUNDLE_IMG)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ build: _print_vars _check_imgs_env _check_skopeo_installed
 	@rm -rf ./generated
 	# Create the bundle and push it to a docker registry
 	docker build -f Dockerfile -t $(BUNDLE_IMG) .
+	docker push $(BUNDLE_IMG)
 
 	BUNDLE_DIGEST=$$(skopeo inspect docker://$(BUNDLE_IMG) | jq -r '.Digest')
 	BUNDLE_IMG=$(BUNDLE_IMG)


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
After upgrading to the 1.0.1 binary needed for devworkspace-controller, I became unable to build the bundle because they shifted commands around (operator-sdk bundle create became operator-sdk generate bundle). Instead of maintaining 2 different versions of operator-sdk locally this PR makes it so that you can use `make build` without operator-sdk installed.

I found out that you can just build the bundle using the Dockerfile in the root. This is actually suggested when you run: `operator-sdk generate bundle`:
```bash
# Then it validates your bundle files and builds your bundle image:
  $ operator-sdk bundle validate ./bundle
  $ docker build -f bundle.Dockerfile -t $BUNDLE_IMG .
  Sending build context to Docker daemon  42.33MB
  Step 1/9 : FROM scratch
```
(bundle.Dockerfile is essentially the same Dockerfile we have in the root of our project except theirs has a few more annotations that we don't need so that's why we just use our Dockerfile to build the bundle) 

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/WTO-26

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
`make build_install`
