### PR TITLE
Make next WTO depends on v1alphax DWO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ _print_vars:
 _select_controller_image:
 ifeq ($(PRODUCTION_ENABLED),true)
 	sed -i.bak \
-	  -e "s|quay.io/devfile/devworkspace-controller:next|quay.io/wto/web-terminal-operator:latest|g" \
+	  -e "s|quay.io/devfile/devworkspace-controller:v1.0.0-alphax|quay.io/wto/web-terminal-operator:latest|g" \
 	  ./manifests/web-terminal.clusterserviceversion.yaml
 	rm ./manifests/web-terminal.clusterserviceversion.yaml.bak
 endif
@@ -26,7 +26,7 @@ endif
 _reset_controller_image:
 ifeq ($(PRODUCTION_ENABLED),true)
 	sed -i.bak \
-	  -e "s|quay.io/wto/web-terminal-operator:latest|quay.io/devfile/devworkspace-controller:next|g" \
+	  -e "s|quay.io/wto/web-terminal-operator:latest|quay.io/devfile/devworkspace-controller:v1.0.0-alphax|g" \
 	  ./manifests/web-terminal.clusterserviceversion.yaml
 	rm ./manifests/web-terminal.clusterserviceversion.yaml.bak
 endif

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
     capabilities: Basic Install
     categories: Developer Tools
     certified: "false"
-    containerImage: quay.io/devfile/devworkspace-controller:next
+    containerImage: quay.io/devfile/devworkspace-controller:v1.0.0-alphax
     createdAt: "2020-10-26T07:24:32Z"
     description: Start a Web Terminal in your browser with common CLI tools for interacting
       with the cluster
@@ -337,8 +337,8 @@ spec:
                 - name: RELATED_IMAGE_openshift_oauth_proxy
                   value: openshift/oauth-proxy:latest
                 - name: RELATED_IMAGE_devworkspace_webhook_server
-                  value: quay.io/devfile/devworkspace-controller:next
-                image: quay.io/devfile/devworkspace-controller:next
+                  value: quay.io/devfile/devworkspace-controller:v1.0.0-alphax
+                image: quay.io/devfile/devworkspace-controller:v1.0.0-alphax
                 imagePullPolicy: Always
                 name: devworkspace-controller
                 resources: {}

--- a/operator-subscription.yaml
+++ b/operator-subscription.yaml
@@ -9,4 +9,4 @@ spec:
   name: web-terminal
   source: custom-web-terminal-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: web-terminal.v1.0.2
+  startingCSV: web-terminal.v1.2.0

--- a/productization/jenkinsfiles/metadata.Jenkinsfile
+++ b/productization/jenkinsfiles/metadata.Jenkinsfile
@@ -66,7 +66,7 @@ timeout(120) {
 
           # Change all references of quay.io/wto to registry-proxy.engineering.redhat.com/rh-osbs
           sed -i -e 's|quay.io/wto|registry-proxy.engineering.redhat.com/rh-osbs|g' \
-                  -e 's|quay.io/devfile/devworkspace-controller:next|registry-proxy.engineering.redhat.com/rh-osbs/web-terminal-operator:''' + VERSION + '''|g' \
+                  -e 's|quay.io/devfile/devworkspace-controller:v1.0.0-alphax|registry-proxy.engineering.redhat.com/rh-osbs/web-terminal-operator:''' + VERSION + '''|g' \
                   -e 's|:latest|:''' + VERSION + '''|g' \
                   manifests/web-terminal.clusterserviceversion.yaml
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes `make install` which is currently broken since WTO pull the next DWO which depends on v1alpha2 which are not in CSV yet.

Note that v1alphax container is built manually and if we get any update on DWO, we need to set up github action to build it.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
