### PR TITLE
Fix build of next dockerimages

### DIFF
--- a/.github/workflows/dockerimage-next.yml
+++ b/.github/workflows/dockerimage-next.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         mkdir -p ~/bin
         cp ~/cache/operator-sdk-${OPERATOR_SDK_VERSION} ~/bin/operator-sdk
-        echo "::add-path::$HOME/bin"
+        echo "$HOME/bin" >> $GITHUB_PATH
 
     - name: Cache OPM ${{ env.OPM_VERSION }}
       uses: actions/cache@v2
@@ -60,7 +60,7 @@ jobs:
       run: |
         mkdir -p ~/bin
         cp ~/cache/opm${OPM_VERSION} ~/bin/opm
-        echo "::add-path::$HOME/bin"
+        echo "$HOME/bin" >> $GITHUB_PATH
 
     - name: Checkout web-terminal-operator source code
       uses: actions/checkout@v2

--- a/.github/workflows/dockerimage-next.yml
+++ b/.github/workflows/dockerimage-next.yml
@@ -20,11 +20,27 @@ jobs:
       BUNDLE_IMG: quay.io/wto/web-terminal-operator-metadata:next
       INDEX_IMG: quay.io/wto/web-terminal-operator-index:next
       OPM_VERSION: v1.13.1
+      OPERATOR_SDK_VERSION: v0.17.2
     steps:
-    - name: Install Operator SDK
-      uses: shivanshs9/setup-k8s-operator-sdk@v1
+
+    - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
+      uses: actions/cache@v2
+      id: cache-operator-sdk
       with:
-        version: "^0.17.0"
+        path: ~/cache
+        key: operator-sdk-${{ env.OPERATOR_SDK_VERSION }}
+
+    - name: Download Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
+      if: steps.cache-operator-sdk.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p ~/cache
+        wget https://github.com/operator-framework/operator-sdk/releases/download/v0.17.2/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -O ~/cache/operator-sdk-${OPERATOR_SDK_VERSION} > /dev/null
+        chmod +x ~/cache/operator-sdk-${OPERATOR_SDK_VERSION}
+    - name: Install Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
+      run: |
+        mkdir -p ~/bin
+        cp ~/cache/operator-sdk-${OPERATOR_SDK_VERSION} ~/bin/operator-sdk
+        echo "::add-path::$HOME/bin"
 
     - name: Cache OPM ${{ env.OPM_VERSION }}
       uses: actions/cache@v2


### PR DESCRIPTION
### What does this PR do?
This PR fixes fixes build of next dockerimage.
There were two issues:
1. ::add-path:: is deprecated https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
2. setup-k8s-operator-sdk is broken https://github.com/shivanshs9/setup-k8s-operator-sdk/issues/4


### What issues does this PR fix or reference?
N/A

### Is it tested? How?
The test run https://github.com/redhat-developer/web-terminal-operator/runs/1861486269?check_suite_focus=true

