### PR TITLE
Add note how to configure custom default image

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,45 @@ This will build and push images defined by the environment variables `BUNDLE_IMG
 
 If you already have the index image pushed to your registry, then you can use the `make install` or `make register_catalogsource` rules with the environment variables defined above to install those images on the cluster.
 
+## Configuring the custom default container
+
+As cluster admin you're able to configure the default container that is used in terminal's devworkspaces with the following entry in configmap:
+
+```bash
+oc patch configmap devworkspace-controller -n openshift-operators --patch "
+data:
+  devworkspace.default_dockerimage.redhat-developer.web-terminal: |
+      name: dev
+      image: quay.io/wto/web-terminal-tooling:latest
+      memoryLimit: 128Mi
+      command: ['tail']
+      args: ['-f', '/dev/null']
+      env:
+      - name: PS1
+        value: '\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]'
+"
+```
+
+<details>
+<summary>The format is different for WTO 1.2 and earlier</summary>
+
+```bash
+oc patch configmap devworkspace-controller -n openshift-operators --patch "
+data:
+  devworkspace.default_dockerimage.redhat-developer.web-terminal: |
+    memoryLimit: 128Mi
+    container:
+      name: dev
+      image: quay.io/wto/web-terminal-tooling:latest
+      command: ['tail']
+      args: ['-f', '/dev/null']
+      env:
+      - name: PS1
+        value: '\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]'
+"
+```
+</details>
+
 ## Removing the operator from a cluster
 
 To remove the WebTerminal Operator and the CatalogSource use


### PR DESCRIPTION
### What does this PR do?
This PR add note how to configure custom default image.
It's different for 1.2 and earlier and 1.3 and future due https://github.com/devfile/devworkspace-operator/pull/319

We may want to backport that fix into 1.2.1 but I'm not sure it worths time.

### What issues does this PR fix or reference?
It depends on https://github.com/devfile/devworkspace-operator/pull/319

### Is it tested? How?
I executed the shared command, and checked that the desired container is started as default for WTO 1.2 and my fresher with https://github.com/devfile/devworkspace-operator/pull/319 included :
```
export BUNDLE_IMG=quay.io/sleshche/che-workspace-bundle:custom-image
export INDEX_IMG=quay.io/sleshche/che-workspace-operator-index:custom-image
```
