### PR TITLE
Re-add tooling

### DIFF
--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -324,6 +324,8 @@ spec:
                       fieldPath: spec.serviceAccountName
                 - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
                   value: quay.io/wto/web-terminal-exec:latest
+                - name: RELATED_IMAGE_web_terminal_tooling
+                  value: quay.io/wto/web-terminal-tooling:latest
                 - name: RELATED_IMAGE_devworkspace_webhook_server
                   value: quay.io/devfile/devworkspace-controller:v1.0.0-alphax
                 image: quay.io/devfile/devworkspace-controller:v1.0.0-alphax


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR re-adds the `RELATED_IMAGE_web_terminal_tooling` env variable that was accidentally removed. Apparently, when I switched the default branch from master to main I forgot to change the branch protection rules so when I accidentally pushed to main it went through :facepalm:. The reason why the other env variables were removed was because in CPaaS we don't have a way of just using yq to filter out env variables we don't need. Instead, it's easiest for me to just have the env variables defined that we want in the product. Otherwise, we'd have to wait for CPaaS to support that feature


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
