### PR TITLE
Use latest WebTerminal plugin instead of 4.5.0

### DIFF
--- a/dev-scripts/webterminal-localhost.sh
+++ b/dev-scripts/webterminal-localhost.sh
@@ -133,7 +133,7 @@ function update_frontend() {
   $PWD/build-frontend.sh
   echo "Reverting patch"
   sed -i.bak -e "s|routingClass: 'basic'|routingClass: 'web-terminal'|" \
-             -e "s|id: 'redhat-developer/web-terminal-dev/4.5.0'|id: 'redhat-developer/web-terminal/4.5.0'|" \
+             -e "s|id: 'redhat-developer/web-terminal-dev/latest'|id: 'redhat-developer/web-terminal/latest'|" \
       $PWD/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
   rm $PWD/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts.bak
 }
@@ -141,7 +141,7 @@ function update_frontend() {
 function patch_frontend() {
   echo "Patching frontend"
   sed -i.bak -e "s|routingClass: 'web-terminal'|routingClass: 'basic'|" \
-             -e "s|id: 'redhat-developer/web-terminal/4.5.0'|id: 'redhat-developer/web-terminal-dev/4.5.0'|" \
+             -e "s|id: 'redhat-developer/web-terminal/latest'|id: 'redhat-developer/web-terminal-dev/latest'|" \
       $PWD/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
   rm $PWD/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts.bak
   git --no-pager diff $PWD/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
               "components": [
                 {
                   "plugin": {
-                    "id": "redhat-developer/web-terminal/4.5.0",
+                    "id": "redhat-developer/web-terminal/latest",
                     "name": "web-terminal"
                   }
                 }


### PR DESCRIPTION
### What does this PR do?
It makes WTO repo use the latest terminal plugin which is available starting from WTO 1.2.1.

It's WIP since it depends on OpenShift Console changes, otherwise devscript won't work https://github.com/openshift/console/pull/8795

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
