### PR TITLE
Add an ability to configure digest evaluation method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,8 @@ register_catalogsource: _print_vars _check_imgs_env _check_skopeo_installed
 	  mv ./catalog-source.yaml.bak ./catalog-source.yaml
 
 	oc apply -f ./imageContentSourcePolicy.yaml
-### Register_catalogsource for e2e tests with pullinng an image and getting Didgest with docker inspect and jq. It allow avoid long delays. 
-### Sometimes scopeo inspect command try to obtains all layers from a registry ant it take a lof of time 30-40 min. 
+### Register_catalogsource for e2e tests with pulling an image and getting Didest with docker inspect and jq. It allow you to avoid long delays. 
+### Sometimes skopeo inspect command try to obtains all layers from a registry and it take up to 30-40 min. 
 register_catalogsource_for_cpaas:
 	podman pull $(INDEX_IMG)
 	IMAGE=$$(podman inspect $(INDEX_IMG) | jq ".[].RepoDigests[0]" -r) 

--- a/Makefile
+++ b/Makefile
@@ -68,26 +68,18 @@ export: _print_vars _check_imgs_env
 	opm index export -c docker -f ./generated/exported-manifests -i $(INDEX_IMG) -o web-terminal
 
 ### register_catalogsource: creates the catalogsource to make the operator be available on the marketplace. Image referenced by INDEX_IMG must be pushed and publicly available
-### the DIGEST of the image for the catalogsource can be obtained with 3 tools: skopeo, docker and podman. The tool is set in the GET_DIGEST_WITH env. variable. Sopeo is used by default.
 register_catalogsource: _print_vars _check_imgs_env _check_skopeo_installed
 
 ifeq ($(GET_DIGEST_WITH),skopeo)
-	echo ">>>>> getting Didgest with skopeo >>>>>"
-	@INDEX_DIGEST=$$(skopeo inspect docker://$(INDEX_IMG) --debug | jq -r '.Digest')
+	@INDEX_DIGEST=$$(skopeo inspect docker://$(INDEX_IMG) | jq -r '.Digest')
 	INDEX_IMG=$(INDEX_IMG)
 	INDEX_IMG_DIGEST="$${INDEX_IMG%:*}@$${INDEX_DIGEST}"
-endif
-
-ifeq ($(GET_DIGEST_WITH),podman)
-	echo ">>>>> getting Didgest with podman >>>>>"
-	podman pull $(INDEX_IMG)
-	INDEX_IMG_DIGEST=$$(podman inspect $(INDEX_IMG) | jq ".[].RepoDigests[0]" -r) 
-endif
-
-ifeq ($(GET_DIGEST_WITH),docker)
-	echo ">>>>> getting Didgest with docker >>>>>"
-	docker pull $(INDEX_IMG)
-	INDEX_IMG_DIGEST=$$(podman inspect $(INDEX_IMG) | jq ".[].RepoDigests[0]" -r) 
+else ifeq ($(GET_DIGEST_WITH),$(filter $(GET_DIGEST_WITH),podman docker))   
+	$(GET_DIGEST_WITH) pull $(INDEX_IMG)
+	INDEX_IMG_DIGEST=$$($(GET_DIGEST_WITH) inspect $(INDEX_IMG) | jq ".[].RepoDigests[0]" -r) 
+else
+	echo "unsupported GET_DIGEST_WITH is configured"
+	exit 1
 endif
 
 	# replace references of catalogsource img with your image
@@ -201,3 +193,4 @@ help: Makefile
 	echo '    PRODUCTION_ENABLED             - If you want to use production images. Set to $(PRODUCTION_ENABLED)'
 	echo '    DEVWORKSPACE_API_VERSION       - Branch or tag of the github.com/devfile/kubernetes-api to depend on.'
 	echo '    DEVWORKSPACE_OPERATOR_VERSION  - The branch/tag of the terminal manifests.'
+	echo '    GET_DIGEST_WITH                - The tool name for obtaining an image didgest. Supported tools: skopeo, podman, docker'


### PR DESCRIPTION
### What does this PR do?
In some specific cases the command can perform too long. For example:  when we try to get **Index Didgest** from a IIB image. For instance: invokation command like `skopeo inspect docker://registry-proxy.engineering.redhat.com/rh-osbs/iib:77245 --debug` can take about 20-30 minutes.
**Screencast:**

![screencast-nimbus-capture-2021 05 26-18_26_32](https://user-images.githubusercontent.com/1640058/119688820-fe6ab800-be50-11eb-987e-e9e268ba61a7.gif)

As alternative solution we can pull the image locally and get the Didgest with jg. It can decrease a gettin the image didgest. This PR add new target to the Makefile


### Is it tested? How?
Has been checked on local crc instance