### PR TITLE
several improvements and fixes after switching WTO to be dependent on DWO

### DIFF
--- a/.github/workflows/dockerimage-next.yml
+++ b/.github/workflows/dockerimage-next.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       BUNDLE_IMG: quay.io/wto/web-terminal-operator-metadata:next
       INDEX_IMG: quay.io/wto/web-terminal-operator-index:next
+      WTO_IMG: quay.io/wto/web-terminal-operator:next
       OPM_VERSION: v1.13.1
       OPERATOR_SDK_VERSION: v0.17.2
     steps:
@@ -71,6 +72,9 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       run: |
         echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin quay.io
+
+    - name: "Build Controller image "
+      run: make build_controller_image
 
     - name: "Build Bundle & Index images"
       run: make build

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Pull Request Checks
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  check-wto-controller:
+    name: Check WTO controller image
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout web-terminal-operator source code
+      uses: actions/checkout@v2
+
+    - name: "Check WTO Controller image"
+      run: docker build -t wto-controller:test -f build/dockerfiles/controller.Dockerfile .

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,6 +14,55 @@ on:
 
 jobs:
 
+  go:
+    name: Check go sources
+    runs-on: ubuntu-20.04
+    steps:
+    -
+      name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+    -
+      name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    -
+      name: Cache go modules
+      id: cache-mod
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    -
+      name: Download dependencies
+      run: go mod download
+      if: steps.cache-mod.outputs.cache-hit != 'true'
+    -
+      name: Check go mod status
+      run: |
+        go mod tidy
+        if [[ ! -z $(git status -s) ]]
+        then
+          echo "Go mod state is not clean:"
+          git --no-pager diff
+          exit 1
+        fi
+    -
+      name: Check format
+      run: |
+        go get -u golang.org/x/tools/cmd/goimports
+        git reset HEAD --hard
+
+        make fmt
+        if [[ $? != 0 ]]
+        then
+          echo "not well formatted sources are found:"
+          git --no-pager diff
+          exit 1
+        fi
+
   check-wto-controller:
     name: Check WTO controller image
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifndef VERBOSE
 MAKEFLAGS += --silent
 endif
 
-include build/makefiles/deployment.mk
+include build/makefiles/controller.mk
 include build/makefiles/version.mk
 
 all: help

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := bash
 .SHELLFLAGS = -ec
 
-WTO_IMG ?= quay.io/wto/web-terminal-operator:latest
+WTO_IMG ?= quay.io/wto/web-terminal-operator:next
 BUNDLE_IMG ?= quay.io/wto/web-terminal-operator-metadata:next
 INDEX_IMG ?= quay.io/wto/web-terminal-operator-index:next
 PRODUCTION_ENABLED ?= false

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ This repo includes a `Makefile` to simplify deploying the Operator to a cluster:
 | `make install` | Register the CatalogSource and install the operator on the cluster. |
 | `make register_catalogsource` | Register the CatalogSource but do not install the operator. This enables the operator to be installed manually through OperatorHub. |
 | `make unregister_catalogsource` | Remove the CatalogSource from the cluster. |
-| `make uninstall` | Remove the installed operator from the cluster |
-| `make purge` | Like `make uninstall`, but do not fail if an error is encountered |
+| `make uninstall` | uninstalls the Web Terminal Operator Subscription and related ClusterServiceVersion |
+| `make uninstall_v1_2` | Remove the installed WTO 1.2 from the cluster |
 
 The commands above require being logged in to the cluster as a `cluster-admin`. See `make help` for a full list of supported environment variables and rules available.
 

--- a/build/dockerfiles/controller.Dockerfile
+++ b/build/dockerfiles/controller.Dockerfile
@@ -10,9 +10,9 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/devtools/go-toolset-rhel7
-FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.14.12-4.1615820747  as builder
-ENV PATH=/opt/rh/go-toolset-1.14/root/usr/bin:${PATH} \
-    GOPATH=/go/
+FROM registry.access.redhat.com/ubi8-minimal:8.4-200 as builder
+RUN microdnf install -y golang unzip make && \
+    go version
 USER root
 
 RUN go env GOPROXY

--- a/build/makefiles/controller.mk
+++ b/build/makefiles/controller.mk
@@ -1,3 +1,24 @@
+### fmt: Runs go fmt against code
+fmt:
+ifneq ($(shell command -v goimports 2> /dev/null),)
+	find . -name '*.go' -exec goimports -w {} \;
+else
+	@echo "WARN: goimports is not installed -- formatting using go fmt instead."
+	@echo "      Please install goimports to ensure file imports are consistent."
+	go fmt -x ./...
+endif
+
+### check_fmt: Checks the formatting on go files in repo
+check_fmt:
+ifeq ($(shell command -v goimports 2> /dev/null),)
+	$(error "goimports must be installed for this rule" && exit 1)
+endif
+	@{
+		if [[ $$(find . -name '*.go' -exec goimports -l {} \;) != "" ]]; then \
+			echo "Files not formatted; run 'make fmt'"; exit 1 ;\
+		fi ;\
+	}
+
 ### compile: Build binary for Web Terminal Operator
 compile:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) GO111MODULE=on go build \

--- a/build/makefiles/deployment.mk
+++ b/build/makefiles/deployment.mk
@@ -10,9 +10,9 @@ compile:
 
 ### build_controller_image: Build container image for Web Terminal Operator
 build_controller_image:
-	$(DOCKER) build -t $(WTO_IMG) -f build/dockerfiles/deployment.Dockerfile .
+	$(DOCKER) build -t $(WTO_IMG) -f build/dockerfiles/controller.Dockerfile .
 ifneq ($(INITIATOR),CI)
-ifeq ($(WTO_IMG),quay.io/wto/web-terminal-operator:latest)
+ifeq ($(WTO_IMG),quay.io/wto/web-terminal-operator:next)
 	@echo -n "Are you sure you want to push $(WTO_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
 endif
 endif

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-developer/web-terminal-operator
 
-go 1.14
+go 1.15
 
 require (
 	github.com/devfile/api/v2 v2.1.0


### PR DESCRIPTION
### What does this PR do?
This PR provides the following changes:
- fix controller image and make github workflow build the next tag;
- return back target for uninstalling WTO 1.2;
- ~~disable an ability to install operator in All namespace mode, since it's redundant in our case at this point, and it's the time we can migrate to newer preferable way;~~ moved to https://github.com/redhat-developer/web-terminal-operator/pull/82
- add pr check to verify go sources and controller images;
- upgrade controller to go 1.15 and use newer way to install go in ubi image suggested in https://github.com/eclipse/che/issues/19762;

### What issues does this PR fix or reference?
It's for https://issues.redhat.com/browse/WTO-101

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
