### PR TITLE
Do not support single namespace install mode

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -28,8 +28,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=web-terminal
-LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+LABEL operators.operatorframework.io.bundle.channels.v1=fast
+LABEL operators.operatorframework.io.bundle.channel.default.v1=fast
 
 # append Brew metadata here
 ENV SUMMARY="Web Terminal - Operator Metadata container" \

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -51,7 +51,6 @@ metadata:
     description: Start a Web Terminal in your browser with common CLI tools for interacting
       with the cluster
     containerImage: quay.io/wto/web-terminal-operator:next
-    operatorframework.io/suggested-namespace: openshift-operators
     repository: https://github.com/redhat-developer/web-terminal-operator/
     support: Red Hat, Inc.
   name: web-terminal.v1.3.0
@@ -171,7 +170,7 @@ spec:
   installModes:
   - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -51,6 +51,7 @@ metadata:
     description: Start a Web Terminal in your browser with common CLI tools for interacting
       with the cluster
     containerImage: quay.io/wto/web-terminal-operator:next
+    operatorframework.io/suggested-namespace: openshift-operators
     repository: https://github.com/redhat-developer/web-terminal-operator/
     support: Red Hat, Inc.
   name: web-terminal.v1.3.0

--- a/metadata/annotations.yaml
+++ b/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: alpha
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: fast
+  operators.operatorframework.io.bundle.channels.v1: fast
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/operator-subscription.yaml
+++ b/operator-subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: web-terminal
   namespace: openshift-operators
 spec:
-  channel: alpha
+  channel: fast
   installPlanApproval: Automatic
   name: web-terminal
   source: custom-web-terminal-catalog


### PR DESCRIPTION
### What does this PR do?
DevWorkspace operator which is a dependency for WTO, is going to be All namespaces mode.
So, it forces WTO to be all namespaces mode, even though WTO does not need to watch all namespaces ATM.
It's agreed with OLM team and they told all operators are moving to all-namespace mode, so it won't be possible to install the same operator twice.

Also, this PR has a dedicated commit to change channel from alpha to fast, it's done due:
- this way we force users to manually uninstall WTO from a new channel;
- fast is name recommended by OLM https://olm.operatorframework.io/docs/best-practices/channel-naming/#naming for 

> Released, supported operators which are still being monitored to assess stability/quality prior to promoting them as stable. Generally used by early adopters or for testing in pre-production environments.


### What issues does this PR fix or reference?
It's for https://issues.redhat.com/browse/WTO-101

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
