### PR TITLE
Update operator description for 1.3.0 and attempt to document uninstall

### DIFF
--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,0 +1,47 @@
+# Uninstalling the Web Terminal Operator
+As of version 1.3.0, the Web Terminal Operator delegates creation of the cluster resources required for Web Terminals to the DevWorkspace Operator, and can be uninstalled from the OperatorHub UI normally. To uninstall the DevWorkspace Operator, manual steps are still required and should be followed according to documentation.
+
+## Version 1.2.1 and below
+Manual steps are required to uninstall the Web Terminal Operator in order to avoid issues with webhooks and finalizers used to secure terminal resources. The Web Terminal Operator utilizes validating webhooks for `pods/exec`, meaning improper uninstallation can block users' ability to exec into pods on the cluster.
+
+1. Ensure that all DevWorkspace Custom Resources are removed along with their related k8s objects, like deployments.
+
+	```
+	kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait
+	kubectl delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
+	kubectl delete components.controller.devfile.io --all-namespaces --all --wait
+	```
+	Note: This step must be done first, as otherwise the resources above may have finalizers that block automatic cleanup.
+
+2. Uninstall the Operator
+
+3. Remove the custom resource definitions installed by the operator
+
+	```
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io
+	```
+
+4. Remove DevWorkspace Webhook Server deployment
+
+	```
+	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators
+	```
+
+5. Remove lingering service, secrets, and configmaps
+
+	```
+	kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator
+	kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators
+	kubectl delete configmap devworkspace-controller -n openshift-operators
+	kubectl delete clusterrole devworkspace-webhook-server
+	kubectl delete clusterrolebinding devworkspace-webhook-server
+	```
+
+6. Remove mutating/validating webhook configurations.
+
+	```
+	kubectl delete mutatingwebhookconfigurations controller.devfile.io
+	kubectl delete validatingwebhookconfigurations controller.devfile.io
+	```

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -28,56 +28,35 @@ spec:
         name: devworkspaces.workspace.devfile.io
         version: v1alpha1
   description: |
-    Start a Web Terminal in your browser with common CLI tools for interacting with the cluster.
+    Start a Web Terminal in your browser with common CLI tools for interacting with
+    the cluster.
 
-    **Note:** The OpenShift console integration that allows easily creating web terminal instances
-    and logging in automatically is available in OpenShift 4.5.3 and higher. In previous versions of
-    OpenShift, the operator can be installed but web terminals will have to be created and accessed
-    manually.
+    **Note:** The Web Terminal Operator integrates with the OpenShift Console in
+    OpenShift 4.5.3 and higher to simplify Web Terminal instance creation and
+    automate OpenShift login. In earlier versions of OpenShift, the operator can
+    be installed but Web Terminals will have to be created and accessed manually.
+
+    ## Description
+    The Web Terminal Operator leverages the
+    [DevWorkspace Operator](https://github.com/devfile/devworkspace-operator)
+    to provision enviroments which support common cloud CLI tools. When this
+    operator is installed, the DevWorkspace Operator will be installed as a
+    dependency.
 
     ## How to Install
-    Press the **Install** button, choose the upgrade strategy, and wait for the **Installed** Operator status.
+    Press the **Install** button, choose the upgrade strategy, and wait for the
+    **Installed** Operator status.
 
-    When the operator is installed, you will see a terminal button appear on the top right of the console.
-
-    **Note:** The Web Terminal does not work with cluster-admin users at this point in time.
+    When the operator is installed, you will see a terminal button appear on the
+    top right of the console after refreshing the OpenShift console window.
 
     ## How to Uninstall
-    Parts of the operator must be manually uninstalled for security purposes. It also allows you to save cluster resources,
-    as terminals cannot be idled when the operator is uninstalled. In order to fully uninstall an admin must:
-
-    1. Ensure that all DevWorkspace Custom Resources are removed along with their related k8s objects, like deployments.
-       It is crucial that this is done first, otherwise finalizers might make it difficult to fully uninstall the operator.
-
-            kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait
-            kubectl delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
-            kubectl delete components.controller.devfile.io --all-namespaces --all --wait
-
-    2. Uninstall the Operator
-
-    3. Remove the custom resource definitions
-
-            kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io
-            kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io
-            kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io
-
-    4. Remove DevWorkspace Webhook Server Deployment itself
-
-            kubectl delete deployment/devworkspace-webhook-server -n openshift-operators
-
-    5. Remove lingering service, secrets, and configmaps
-
-            kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
-            kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators
-            kubectl delete configmap devworkspace-controller -n openshift-operators
-            kubectl delete clusterrole devworkspace-webhook-server
-            kubectl delete clusterrolebinding devworkspace-webhook-server
-
-    6. Remove mutating/validating webhook configurations. _note:_ there may be a few seconds where you cannot exec into
-       pods between steps 4 and 6. This is expected. Once you remove the webhooks you will be able to exec into pods again.
-
-            kubectl delete mutatingwebhookconfigurations controller.devfile.io
-            kubectl delete validatingwebhookconfigurations controller.devfile.io
+    The Web Terminal Operator requires manual steps to fully uninstall the operator.
+    As the Web Terminal Operator is designed as a way to access the OpenShift
+    cluster, Web Terminal instances store user credentials. To avoid exposing these
+    credentials to unwanted parties, the operator deploys webhooks and finalizers
+    that aren't removed when the operator is uninstalled. See the
+    [uninstall guide](TODO) for more details.
 
     ## Known Issues
     1. [Occasionally you will need to press enter to get a prompt inside of the web-terminal](https://issues.redhat.com/browse/WTO-43)


### PR DESCRIPTION
### What does this PR do?
Update WTO csv description for 1.3.0. I think we should probably avoid attempting to document the uninstall process within the description itself, as the process is going to be different between version 1.2.1 and 1.3.0. I've started an `uninstall.md` to begin documenting this, though it should be surfaced in a more official way.

There are a couple of TODO links in the descriptions, as I'm not sure if we should e.g. include a link to the [OpenShift docs](https://docs.openshift.com/container-platform/4.7/web_console/odc-about-web-terminal.html#odc-uninstalling-web-terminal_odc-about-web-terminal), since those are version-specific and will be out of date on 4.8.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
N/A