### PR TITLE
Add annotation to Web Terminal DWTs to allow reading anywhere

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -13,6 +13,8 @@
 package config
 
 const (
+	PermittedNamespacesAnnotation = "controller.devfile.io/allow-import-from"
+
 	ToolingTemplateName       = "web-terminal-tooling"
 	ExecTemplateName          = "web-terminal-exec"
 	DefaultTemplatesNamespace = "openshift-operators"

--- a/pkg/webterminal/exec.go
+++ b/pkg/webterminal/exec.go
@@ -57,6 +57,9 @@ func getSpecExecTemplate() (*dw.DevWorkspaceTemplate, error) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:      config.ExecTemplateName,
 			Namespace: config.DefaultTemplatesNamespace,
+			Annotations: map[string]string{
+				config.PermittedNamespacesAnnotation: "*",
+			},
 		},
 		Spec: dw.DevWorkspaceTemplateSpec{
 			DevWorkspaceTemplateSpecContent: dw.DevWorkspaceTemplateSpecContent{

--- a/pkg/webterminal/tooling.go
+++ b/pkg/webterminal/tooling.go
@@ -55,6 +55,9 @@ func getSpecToolingTemplate() (*dw.DevWorkspaceTemplate, error) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:      config.ToolingTemplateName,
 			Namespace: config.DefaultTemplatesNamespace,
+			Annotations: map[string]string{
+				config.PermittedNamespacesAnnotation: "*",
+			},
 		},
 		Spec: dw.DevWorkspaceTemplateSpec{
 			DevWorkspaceTemplateSpecContent: dw.DevWorkspaceTemplateSpecContent{


### PR DESCRIPTION
### What does this PR do?
Adapts WTO to PR https://github.com/devfile/devworkspace-operator/pull/466 (allow WTO dwts to be read in all namespaces).

Should not be merged until https://github.com/devfile/devworkspace-operator/pull/466 is merged.

### What issues does this PR fix or reference?
Related to https://github.com/devfile/devworkspace-operator/issues/403

### Is it tested? How?
Should be no change in functionality.
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
