### PR TITLE
Update uninstall steps in description to link to OpenShift docs.

### DIFF
--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -56,7 +56,8 @@ spec:
     cluster, Web Terminal instances store user credentials. To avoid exposing these
     credentials to unwanted parties, the operator deploys webhooks and finalizers
     that aren't removed when the operator is uninstalled. See the
-    [uninstall guide](TODO) for more details.
+    [uninstall guide](https://docs.openshift.com/container-platform/latest/web_console/odc-about-web-terminal.html) 
+    for more details.
 
     ## Known Issues
     1. [Occasionally you will need to press enter to get a prompt inside of the web-terminal](https://issues.redhat.com/browse/WTO-43)


### PR DESCRIPTION
### What does this PR do?
Update the link used for the uninstall steps to point at the OpenShift docs: https://docs.openshift.com/container-platform/latest/web_console/odc-about-web-terminal.html

I've set it to point at the latest version, to avoid issues of out-of-date links on future releases.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
