### PR TITLE
Label DevWorkspaceTemplates to allow easier removal

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -29,3 +29,9 @@ const (
 	ExecCPURequest    = "100m"
 	ExecCPULimit      = "400m"
 )
+
+var (
+	DefaultTemplatesLabels = map[string]string{
+		"console.openshift.io/terminal": "true",
+	}
+)

--- a/pkg/webterminal/exec.go
+++ b/pkg/webterminal/exec.go
@@ -60,6 +60,7 @@ func getSpecExecTemplate() (*dw.DevWorkspaceTemplate, error) {
 			Annotations: map[string]string{
 				config.PermittedNamespacesAnnotation: "*",
 			},
+			Labels: config.DefaultTemplatesLabels,
 		},
 		Spec: dw.DevWorkspaceTemplateSpec{
 			DevWorkspaceTemplateSpecContent: dw.DevWorkspaceTemplateSpecContent{

--- a/pkg/webterminal/tooling.go
+++ b/pkg/webterminal/tooling.go
@@ -58,6 +58,7 @@ func getSpecToolingTemplate() (*dw.DevWorkspaceTemplate, error) {
 			Annotations: map[string]string{
 				config.PermittedNamespacesAnnotation: "*",
 			},
+			Labels: config.DefaultTemplatesLabels,
 		},
 		Spec: dw.DevWorkspaceTemplateSpec{
 			DevWorkspaceTemplateSpecContent: dw.DevWorkspaceTemplateSpecContent{


### PR DESCRIPTION
### What does this PR do?
Apply a common label (shared with web terminal instances themselves) to DevWorkspaceTemplates created by the Web Terminal Operator in order to make their removal easier.

### What issues does this PR fix or reference?
Helps with documenting how to uninstall the operator, as we can remove these templates in a targetted way.

### Is it tested? How?
Should be no changes functionally.
