### PR TITLE
WIP: Generate a combined.yaml that can be used to deploy WTO without OLM

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -62,6 +62,16 @@ jobs:
           git --no-pager diff
           exit 1
         fi
+    -
+      name: Check deploy files
+      run: |
+        make parse_deploy_yaml
+        if [[ ! -z $(git status -s) ]]
+        then
+          echo "Templates in deploy/ dir are not up to date -- run 'make parse_deploy_yaml':"
+          git --no-pager diff
+          exit 1
+        fi
 
   check-wto-controller:
     name: Check WTO controller image

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,10 @@ uninstall_v1_2:
 	kubectl delete mutatingwebhookconfigurations controller.devfile.io
 	kubectl delete validatingwebhookconfigurations controller.devfile.io
 
+### parse_deploy_yaml: extracts the kubernetes objects (deployment, clusterrole, etc.) from manifests so that they can be applied directly to the cluster
+parse_deploy_yaml:
+	deploy/extract_objs.sh
+
 _check_imgs_env:
 ifndef BUNDLE_IMG
 	$(error "BUNDLE_IMG not set")

--- a/deploy/combined.yaml
+++ b/deploy/combined.yaml
@@ -1,0 +1,80 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: web-terminal-controller-rolebinding
+  labels:
+    app.kubernetes.io/name: web-terminal-controller
+    app.kubernetes.io/part-of: web-terminal-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: web-terminal-controller-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: web-terminal-controller
+    namespace: openshift-operators
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: web-terminal-controller-clusterrole
+  labels:
+    app.kubernetes.io/name: web-terminal-controller
+    app.kubernetes.io/part-of: web-terminal-operator
+rules:
+  - apiGroups:
+      - workspace.devfile.io
+    resources:
+      - devworkspacetemplates
+    verbs:
+      - '*'
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-terminal-controller
+  namespace: openshift-operators
+  labels:
+    app.kubernetes.io/name: web-terminal-controller
+    app.kubernetes.io/part-of: web-terminal-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: web-terminal-controller
+      app.kubernetes.io/part-of: web-terminal-operator
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/restartedAt: ''
+      labels:
+        app.kubernetes.io/name: web-terminal-controller
+        app.kubernetes.io/part-of: web-terminal-operator
+    spec:
+      containers:
+        - env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: web-terminal-operator
+            - name: RELATED_IMAGE_web_terminal_tooling
+              value: quay.io/wto/web-terminal-tooling:latest
+            - name: RELATED_IMAGE_web_terminal_exec
+              value: quay.io/eclipse/che-machine-exec:nightly
+          image: quay.io/wto/web-terminal-operator:next
+          imagePullPolicy: Always
+          name: web-terminal-controller
+          resources: {}
+      serviceAccountName: web-terminal-controller
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: web-terminal-controller
+    app.kubernetes.io/part-of: web-terminal-operator
+  name: web-terminal-controller
+  namespace: openshift-operators

--- a/deploy/extract_objs.sh
+++ b/deploy/extract_objs.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+
+COMBINED_YAML_PATH="${SCRIPT_DIR}/combined.yaml"
+OBJECTS_YAML_DIR="${SCRIPT_DIR}/objects"
+
+WEB_TERMINAL_SA_NAME="web-terminal-controller"
+DEPLOYMENT_YAML_PATH="$OBJECTS_YAML_DIR/web-terminal-controller.Deployment.yaml"
+CLUSTERROLE_YAML_PATH="$OBJECTS_YAML_DIR/web-terminal-controller.ClusterRole.yaml"
+CLUSTERROLEBINDING_YAML_PATH="$OBJECTS_YAML_DIR/web-terminal-controller.ClusterRoleBinding.yaml"
+
+rm -rf "$COMBINED_YAML_PATH" "$OBJECTS_YAML_DIR"
+mkdir -p "$OBJECTS_YAML_DIR"
+
+# Parse the deployment yaml out of a CSV
+# Params:
+#   $1 : path to CSV yaml file
+parse_deployment() {
+  local file="$1"
+  yq -y '.spec.install.spec.deployments[] |
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "name": .name,
+      "namespace": "openshift-operators",
+      "labels": {
+        "app.kubernetes.io/name": "web-terminal-controller",
+        "app.kubernetes.io/part-of": "web-terminal-operator"
+      }
+    }
+  } + {"spec": .spec}' "$file" > "$DEPLOYMENT_YAML_PATH"
+}
+
+# Parse the ClusterRole out of a CSV
+# Params:
+#   $1 : path to CSV yaml file
+parse_clusterrole() {
+  local file="$1"
+  yq -y '.spec.install.spec.permissions[] |
+  {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "ClusterRole",
+    "metadata": {
+      "name": "web-terminal-controller-clusterrole",
+      "labels": {
+        "app.kubernetes.io/name": "web-terminal-controller",
+        "app.kubernetes.io/part-of": "web-terminal-operator"
+      }
+    }
+  } + {"rules": .rules}' "$file" > "$CLUSTERROLE_YAML_PATH"
+}
+
+# Create ClusterRoleBinding yaml
+parse_clusterrolebinding() {
+  cat <<EOF > "$CLUSTERROLEBINDING_YAML_PATH"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: web-terminal-controller-rolebinding
+  labels:
+    app.kubernetes.io/name: web-terminal-controller
+    app.kubernetes.io/part-of: web-terminal-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: web-terminal-controller-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: ${WEB_TERMINAL_SA_NAME}
+  namespace: openshift-operators
+EOF
+}
+
+combine_yamls() {
+  yq -y '.' "$OBJECTS_YAML_DIR"/* > "$COMBINED_YAML_PATH"
+}
+
+for file in manifests/*; do
+  echo "Processing file $file"
+  KIND=$(yq -r '.kind' "$file")
+  if [ "$KIND" == "ClusterServiceVersion" ]; then
+    parse_deployment "$file"
+    parse_clusterrole "$file"
+    parse_clusterrolebinding
+  else
+    NAME=$(yq -r '.metadata.name' "$file")
+    yq -y '. * {"metadata": {"namespace": "openshift-operators"}}' "$file" \
+      > "deploy/objects/${NAME}.${KIND}.yaml"
+  fi
+done
+
+combine_yamls

--- a/deploy/objects/web-terminal-controller.ClusterRole.yaml
+++ b/deploy/objects/web-terminal-controller.ClusterRole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: web-terminal-controller-clusterrole
+  labels:
+    app.kubernetes.io/name: web-terminal-controller
+    app.kubernetes.io/part-of: web-terminal-operator
+rules:
+  - apiGroups:
+      - workspace.devfile.io
+    resources:
+      - devworkspacetemplates
+    verbs:
+      - '*'

--- a/deploy/objects/web-terminal-controller.ClusterRoleBinding.yaml
+++ b/deploy/objects/web-terminal-controller.ClusterRoleBinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: web-terminal-controller-rolebinding
+  labels:
+    app.kubernetes.io/name: web-terminal-controller
+    app.kubernetes.io/part-of: web-terminal-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: web-terminal-controller-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: web-terminal-controller
+  namespace: openshift-operators

--- a/deploy/objects/web-terminal-controller.Deployment.yaml
+++ b/deploy/objects/web-terminal-controller.Deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-terminal-controller
+  namespace: openshift-operators
+  labels:
+    app.kubernetes.io/name: web-terminal-controller
+    app.kubernetes.io/part-of: web-terminal-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: web-terminal-controller
+      app.kubernetes.io/part-of: web-terminal-operator
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/restartedAt: ''
+      labels:
+        app.kubernetes.io/name: web-terminal-controller
+        app.kubernetes.io/part-of: web-terminal-operator
+    spec:
+      containers:
+        - env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: web-terminal-operator
+            - name: RELATED_IMAGE_web_terminal_tooling
+              value: quay.io/wto/web-terminal-tooling:latest
+            - name: RELATED_IMAGE_web_terminal_exec
+              value: quay.io/eclipse/che-machine-exec:nightly
+          image: quay.io/wto/web-terminal-operator:next
+          imagePullPolicy: Always
+          name: web-terminal-controller
+          resources: {}
+      serviceAccountName: web-terminal-controller

--- a/deploy/objects/web-terminal-controller.ServiceAccount.yaml
+++ b/deploy/objects/web-terminal-controller.ServiceAccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: web-terminal-controller
+    app.kubernetes.io/part-of: web-terminal-operator
+  name: web-terminal-controller
+  namespace: openshift-operators


### PR DESCRIPTION
### What does this PR do?
This is a WIP for generating the equivalent of [combined.yaml](https://github.com/devfile/devworkspace-operator/blob/main/deploy/deployment/openshift/combined.yaml) in DWO. Relevant Kubernetes objects are extracted from the manifests directory, allowing WTO to be deployed by `oc apply -f <url-to-combined.yaml>`

### What issues does this PR fix or reference?
N/A, but could be useful for testing latest changes in WTO/DWO without the need to build indexes/register catalogsources.

### Is it tested? How?
Generated files are in PR; they apply without issue to minikube cluster (and WTO deployment successfully creates DWTs as expected). Haven't tested on OpenShift, as I don't have a cluster handy at the moment. 
