### PR TITLE
Introduce the ability to install web terminal operator in other names…

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ package config
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 )
 
@@ -37,3 +38,12 @@ func GetDefaultExecImage() (string, error) {
 	}
 	return val, nil
 }
+
+func GetNamespace() (string, error) {
+	namespace, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return "", err
+	}
+	return string(namespace), err
+}
+

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -17,7 +17,6 @@ const (
 
 	ToolingTemplateName       = "web-terminal-tooling"
 	ExecTemplateName          = "web-terminal-exec"
-	DefaultTemplatesNamespace = "openshift-operators"
 
 	ToolingMemoryRequest = "128Mi"
 	ToolingMemoryLimit   = "256Mi"

--- a/pkg/webterminal/defaults.go
+++ b/pkg/webterminal/defaults.go
@@ -14,6 +14,7 @@ package webterminal
 
 import (
 	"context"
+	"github.com/redhat-developer/web-terminal-operator/pkg/config"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,11 +26,17 @@ var (
 
 func SetupDefaultWebTerminalTemplates(ctx context.Context, client crclient.Client) error {
 	log.Info("Syncing DevWorkspaceTemplate for Web Terminal Tooling")
-	if err := syncToolingTemplate(ctx, client); err != nil {
+
+	namespace, err := config.GetNamespace()
+	if err != nil {
+		return err
+	}
+
+	if err := syncToolingTemplate(ctx, client, namespace); err != nil {
 		return err
 	}
 	log.Info("Syncing DevWorkspaceTemplate for Web Terminal Exec")
-	if err := syncExecTemplate(ctx, client); err != nil {
+	if err := syncExecTemplate(ctx, client, namespace); err != nil {
 		return err
 	}
 

--- a/pkg/webterminal/exec.go
+++ b/pkg/webterminal/exec.go
@@ -25,12 +25,12 @@ import (
 	"github.com/redhat-developer/web-terminal-operator/pkg/config"
 )
 
-func syncExecTemplate(ctx context.Context, client crclient.Client) error {
-	clusterDWT, err := getClusterExecTemplate(ctx, client)
+func syncExecTemplate(ctx context.Context, client crclient.Client, namespace string) error {
+	clusterDWT, err := getClusterExecTemplate(ctx, client, namespace)
 	if err != nil {
 		return err
 	}
-	specDWT, err := getSpecExecTemplate()
+	specDWT, err := getSpecExecTemplate(namespace)
 	if err != nil {
 		return nil
 	}
@@ -44,7 +44,7 @@ func syncExecTemplate(ctx context.Context, client crclient.Client) error {
 	return nil
 }
 
-func getSpecExecTemplate() (*dw.DevWorkspaceTemplate, error) {
+func getSpecExecTemplate(namespace string) (*dw.DevWorkspaceTemplate, error) {
 	image, err := config.GetDefaultExecImage()
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func getSpecExecTemplate() (*dw.DevWorkspaceTemplate, error) {
 	dwt := &dw.DevWorkspaceTemplate{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      config.ExecTemplateName,
-			Namespace: config.DefaultTemplatesNamespace,
+			Namespace: namespace,
 			Annotations: map[string]string{
 				config.PermittedNamespacesAnnotation: "*",
 			},
@@ -104,11 +104,11 @@ func getSpecExecTemplate() (*dw.DevWorkspaceTemplate, error) {
 	return dwt, nil
 }
 
-func getClusterExecTemplate(ctx context.Context, client crclient.Client) (*dw.DevWorkspaceTemplate, error) {
+func getClusterExecTemplate(ctx context.Context, client crclient.Client, namespace string) (*dw.DevWorkspaceTemplate, error) {
 	execTemplate := &dw.DevWorkspaceTemplate{}
 	execRef := types.NamespacedName{
 		Name:      config.ExecTemplateName,
-		Namespace: config.DefaultTemplatesNamespace,
+		Namespace: namespace,
 	}
 	err := client.Get(ctx, execRef, execTemplate)
 	if err != nil {

--- a/pkg/webterminal/tooling.go
+++ b/pkg/webterminal/tooling.go
@@ -24,12 +24,12 @@ import (
 	"github.com/redhat-developer/web-terminal-operator/pkg/config"
 )
 
-func syncToolingTemplate(ctx context.Context, client crclient.Client) error {
-	clusterDWT, err := getClusterToolingTemplate(ctx, client)
+func syncToolingTemplate(ctx context.Context, client crclient.Client, namespace string) error {
+	clusterDWT, err := getClusterToolingTemplate(ctx, client, namespace)
 	if err != nil {
 		return err
 	}
-	specDWT, err := getSpecToolingTemplate()
+	specDWT, err := getSpecToolingTemplate(namespace)
 	if err != nil {
 		return nil
 	}
@@ -44,7 +44,7 @@ func syncToolingTemplate(ctx context.Context, client crclient.Client) error {
 	return nil
 }
 
-func getSpecToolingTemplate() (*dw.DevWorkspaceTemplate, error) {
+func getSpecToolingTemplate(namespace string) (*dw.DevWorkspaceTemplate, error) {
 	image, err := config.GetDefaultToolingImage()
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func getSpecToolingTemplate() (*dw.DevWorkspaceTemplate, error) {
 	dwt := &dw.DevWorkspaceTemplate{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      config.ToolingTemplateName,
-			Namespace: config.DefaultTemplatesNamespace,
+			Namespace: namespace,
 			Annotations: map[string]string{
 				config.PermittedNamespacesAnnotation: "*",
 			},
@@ -87,11 +87,11 @@ func getSpecToolingTemplate() (*dw.DevWorkspaceTemplate, error) {
 	return dwt, nil
 }
 
-func getClusterToolingTemplate(ctx context.Context, client crclient.Client) (*dw.DevWorkspaceTemplate, error) {
+func getClusterToolingTemplate(ctx context.Context, client crclient.Client, namespace string) (*dw.DevWorkspaceTemplate, error) {
 	toolingTemplate := &dw.DevWorkspaceTemplate{}
 	toolingRef := types.NamespacedName{
 		Name:      config.ToolingTemplateName,
-		Namespace: config.DefaultTemplatesNamespace,
+		Namespace: namespace,
 	}
 	err := client.Get(ctx, toolingRef, toolingTemplate)
 	if err != nil {


### PR DESCRIPTION
…paces

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR makes it so that the devworkspace templates are installed in the same namespace that the controller is installed in


### What issues does this PR fix or reference?
Part of https://issues.redhat.com/projects/WTO/issues/WTO-99
Related PRs: https://github.com/openshift/console/pull/10045 and https://github.com/openshift/console-operator/


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
_Will add tomorrow_
