### PR TITLE
WIP: Add basic mechanism for detecting OpenShift version in controller

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	dwv1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
 	dwv2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 
+	"github.com/redhat-developer/web-terminal-operator/pkg/versioning"
 	"github.com/redhat-developer/web-terminal-operator/pkg/webterminal"
 )
 
@@ -45,6 +46,12 @@ func init() {
 
 func main() {
 	ctrl.SetLogger(zap.New())
+
+	err := versioning.InitVersioning()
+	if err != nil {
+		setupLog.Error(err, "Failed to detect cluster version")
+		os.Exit(1)
+	}
 
 	cfg, err := ctrlconfig.GetConfig()
 	if err != nil {

--- a/pkg/versioning/versioning.go
+++ b/pkg/versioning/versioning.go
@@ -1,0 +1,57 @@
+package versioning
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	log = ctrl.Log.WithName("versioning")
+
+	kubeMajorVersion string
+	kubeMinorVersion string
+	openShiftVersion string
+
+	// Correspondence between Kubernetes server versions and OpenShift versions
+	// Pulled from https://access.redhat.com/solutions/4870701
+	k8sToOpenShiftVersions = map[string]string{
+		"1.13": "4.1",
+		"1.14": "4.2",
+		"1.16": "4.3",
+		"1.17": "4.4",
+		"1.18": "4.5",
+		"1.19": "4.6",
+		"1.20": "4.7",
+		"1.21": "4.8",
+	}
+)
+
+func InitVersioning() error {
+	// creates the in-cluster config
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return err
+	}
+	disclient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return err
+	}
+	ver, err := disclient.ServerVersion()
+	if err != nil {
+		return err
+	}
+
+	kubeMajorVersion = ver.Major
+	kubeMinorVersion = ver.Minor
+	openShiftVersion = k8sToOpenShiftVersions[fmt.Sprintf("%s.%s", ver.Major, ver.Minor)]
+	if openShiftVersion == "" {
+		openShiftVersion = "version unknown"
+	}
+
+	log.Info(fmt.Sprintf("Detected Kubernetes version %s.%s, corresponding to OpenShift %s", ver.Major, ver.Minor, openShiftVersion))
+
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?
Adds a basic way of detecting the version of OpenShift running in the cluster. WIP becuase this is just a proof-of-concept for now, but this could be extended in order to provide corresponding versions of tooling for each version of OpenShift.

### What issues does this PR fix or reference?
Part of bundling multiple versions of tooling/exec into one release of WTO.

### Is it tested? How?
Tested by deploying locally. For now, we just have the log message, e.g. 
```
{"level":"info","ts":1634237903.638952,"logger":"versioning","msg":"Detected Kubernetes version 1.21, corresponding to OpenShift 4.8"}
```
