### PR TITLE
Add script for testing controller deployment directly without OLM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 SHELL := bash
 .SHELLFLAGS = -ec
 
-WTO_IMG ?= quay.io/wto/web-terminal-operator:next
-BUNDLE_IMG ?= quay.io/wto/web-terminal-operator-metadata:next
-INDEX_IMG ?= quay.io/wto/web-terminal-operator-index:next
+export WTO_IMG ?= quay.io/wto/web-terminal-operator:next
+export BUNDLE_IMG ?= quay.io/wto/web-terminal-operator-metadata:next
+export INDEX_IMG ?= quay.io/wto/web-terminal-operator-index:next
+export NAMESPACE ?= openshift-operators
+
 PRODUCTION_ENABLED ?= false
 LATEST_INDEX_IMG ?= quay.io/wto/web-terminal-operator-index:latest
 GET_DIGEST_WITH ?= skopeo
@@ -26,6 +28,7 @@ _print_vars:
 	echo "    BUNDLE_IMG=$(BUNDLE_IMG)"
 	echo "    INDEX_IMG=$(INDEX_IMG)"
 	echo "    LATEST_INDEX_IMG=$(LATEST_INDEX_IMG)"
+	echo "    NAMESPACE=$(NAMESPACE)"
 
 ### build: build the terminal bundle and index and push them to a docker registry
 build: _print_vars _check_imgs_env _check_skopeo_installed

--- a/build/makefiles/controller.mk
+++ b/build/makefiles/controller.mk
@@ -38,3 +38,11 @@ ifeq ($(WTO_IMG),quay.io/wto/web-terminal-operator:next)
 endif
 endif
 	$(DOCKER) push $(WTO_IMG)
+
+### parse_deploy_yaml: extracts the kubernetes objects (deployment, clusterrole, etc.) from manifests so that they can be applied directly to the cluster
+parse_deploy_yaml:
+	deploy/extract_objs.sh
+
+### test_controller: applies controller deployment and related resources directly to the cluster (i.e. without OLM) for testing
+test_controller: parse_deploy_yaml
+	cat generated/internal/combined.yaml | envsubst | kubectl apply -f -

--- a/deploy/extract_objs.sh
+++ b/deploy/extract_objs.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+REPO_DIR="${SCRIPT_DIR}/.."
+OUTPUT_DIR="${REPO_DIR}/generated/internal"
+
+COMBINED_YAML_PATH="${OUTPUT_DIR}/combined.yaml"
+OBJECTS_YAML_DIR="${OUTPUT_DIR}/objects"
+
+WEB_TERMINAL_SA_NAME="web-terminal-controller"
+DEPLOYMENT_YAML_PATH="$OBJECTS_YAML_DIR/web-terminal-controller.Deployment.yaml"
+CLUSTERROLE_YAML_PATH="$OBJECTS_YAML_DIR/web-terminal-controller.ClusterRole.yaml"
+CLUSTERROLEBINDING_YAML_PATH="$OBJECTS_YAML_DIR/web-terminal-controller.ClusterRoleBinding.yaml"
+
+rm -rf "$COMBINED_YAML_PATH" "$OBJECTS_YAML_DIR"
+mkdir -p "$OBJECTS_YAML_DIR"
+
+# Parse the deployment yaml out of a CSV
+# Params:
+#   $1 : path to CSV yaml file
+parse_deployment() {
+  local file="$1"
+  yq -y '.spec.install.spec.deployments[] |
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "name": .name,
+      "namespace": "${NAMESPACE}",
+      "labels": {
+        "app.kubernetes.io/name": "web-terminal-controller",
+        "app.kubernetes.io/part-of": "web-terminal-operator"
+      }
+    }
+  } + {"spec": .spec} |
+  .spec.template.spec.containers[0].image = "${WTO_IMG}"' "$file" > "$DEPLOYMENT_YAML_PATH"
+}
+
+# Parse the ClusterRole out of a CSVOn branch local-testing
+
+parse_clusterrole() {
+  local file="$1"
+  yq -y '.spec.install.spec.permissions[] |
+  {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "ClusterRole",
+    "metadata": {
+      "name": "web-terminal-controller-clusterrole",
+      "labels": {
+        "app.kubernetes.io/name": "web-terminal-controller",
+        "app.kubernetes.io/part-of": "web-terminal-operator"
+      }
+    }
+  } + {"rules": .rules}' "$file" > "$CLUSTERROLE_YAML_PATH"
+}
+
+# Create ClusterRoleBinding yaml
+parse_clusterrolebinding() {
+  cat <<EOF > "$CLUSTERROLEBINDING_YAML_PATH"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: web-terminal-controller-rolebinding
+  labels:
+    app.kubernetes.io/name: web-terminal-controller
+    app.kubernetes.io/part-of: web-terminal-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: web-terminal-controller-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: ${WEB_TERMINAL_SA_NAME}
+  namespace: ${NAMESPACE}
+EOF
+}
+
+combine_yamls() {
+  yq -y '.' "$OBJECTS_YAML_DIR"/* > "$COMBINED_YAML_PATH"
+}
+
+for file in manifests/*; do
+  echo "Processing file $file"
+  KIND=$(yq -r '.kind' "$file")
+  if [ "$KIND" == "ClusterServiceVersion" ]; then
+    parse_deployment "$file"
+    parse_clusterrole "$file"
+    parse_clusterrolebinding
+  else
+    NAME=$(yq -r '.metadata.name' "$file")
+    yq -y '. * {"metadata": {"namespace": "${NAMESPACE}"}}' "$file" \
+      > "${OBJECTS_YAML_DIR}/${NAME}.${KIND}.yaml"
+  fi
+done
+
+combine_yamls


### PR DESCRIPTION
### What does this PR do?
Add script and makefile rules to allow deploying the controller to a
cluster without building an OLM bundle. New makefile rules are

- parse_deploy_yaml: parse objects out of OLM manifests
- test_controller: apply results from above to cluster, respecting env
  vars ${WTO_IMG} and ${NAMESPACE}

### What issues does this PR fix or reference?
Minor annoyance while testing e.g. https://github.com/redhat-developer/web-terminal-operator/pull/98

### Is it tested? How?
Execute `make test_controller`