### PR TITLE
Update requirements in CSV to use v1alpha2 DevWorkspace APIVersion

### DIFF
--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ spec:
         version: v1alpha1
       - kind: DevWorkspace
         name: devworkspaces.workspace.devfile.io
-        version: v1alpha1
+        version: v1alpha2
   description: |
     Start a Web Terminal in your browser with common CLI tools for interacting with
     the cluster.


### PR DESCRIPTION
### What does this PR do?
Update the requirements in WTO's CSV to reference `v1alpha2` DevWorkspaces

### What issues does this PR fix or reference?
`v1alpha1` DevWorkspaces are no longer served as of `v0.10.0`

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
