### PR TITLE
Decouple web terminal idle timeout from DevWorkspace idle timeout

### DIFF
--- a/pkg/webterminal/exec.go
+++ b/pkg/webterminal/exec.go
@@ -81,8 +81,13 @@ func getSpecExecTemplate(namespace string) (*dw.DevWorkspaceTemplate, error) {
 						ComponentUnion: dw.ComponentUnion{
 							Container: &dw.ContainerComponent{
 								Container: dw.Container{
-									Image:         image,
-									Env:           nil,
+									Image: image,
+									Env: []dw.EnvVar{
+										{
+											Name:  "WEB_TERMINAL_IDLE_TIMEOUT",
+											Value: "15m",
+										},
+									},
 									MemoryLimit:   config.ExecMemoryLimit,
 									MemoryRequest: config.ExecMemoryRequest,
 									CpuLimit:      config.ExecCPULimit,
@@ -90,7 +95,7 @@ func getSpecExecTemplate(namespace string) (*dw.DevWorkspaceTemplate, error) {
 									Command: []string{
 										"/go/bin/che-machine-exec",
 										"--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
-										"--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
+										"--idle-timeout", "$(WEB_TERMINAL_IDLE_TIMEOUT)",
 										"--pod-selector", "controller.devfile.io/devworkspace_id=$(DEVWORKSPACE_ID)",
 										"--use-tls",
 										"--use-bearer-token",


### PR DESCRIPTION
### What does this PR do?
Set timeout for web terminals through an environment variable in the web-terminal-exec plugin rather than through the automatically provisioned DEVWORKSPACE_IDLE_TIMEOUT environment variable. This allows
the timeout for individual terminals to be changed without overriding the timeout for all DevWorkspaces

The main reason to update the idle timeout currently is that the bash history is erased when a Web Terminal is idled. By setting a longer duration, a session could continue for e.g. a full work day.

### What issues does this PR fix or reference?
We've had a number of requests for how to increase the web terminal timeout, which normally requires editing the DevWorkspace Operator config or the `web-terminal-exec`. With these changes, it's easy to override the timeout for individual web terminals in a persistent way.

### Is it tested? How?
Start a web terminal with these changes and verify that the updated variable is used for idle timeout. To shorten it for the current web terminal, paste and execute the command 

```bash
kubectl get dw -o json \
  -n $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace) \
  $DEVWORKSPACE_NAME \
  | jq '.spec.template.components[1].plugin.components = [{
      "name": "web-terminal-exec",
      "container": {
        "env": [{
          "name": "WEB_TERMINAL_IDLE_TIMEOUT",
          "value": "15s",
        }]
      },
    }]' \
  | kubectl apply -f -
```
