### PR TITLE
Fix localhost script

### DIFF
--- a/dev-scripts/webterminal-localhost.sh
+++ b/dev-scripts/webterminal-localhost.sh
@@ -138,7 +138,7 @@ function update_frontend() {
   $PWD/build-frontend.sh
   echo "Reverting patch"
   sed -i.bak -e "s|routingClass: 'basic'|routingClass: 'web-terminal'|" \
-             -e "s|id: 'redhat-developer/web-terminal-dev/latest'|id: 'redhat-developer/web-terminal/latest'|" \
+             -e "/components:.*web-terminal-exec/d" \
       $PWD/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
   rm $PWD/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts.bak
 }
@@ -146,7 +146,9 @@ function update_frontend() {
 function patch_frontend() {
   echo "Patching frontend"
   sed -i.bak -e "s|routingClass: 'web-terminal'|routingClass: 'basic'|" \
-             -e "s|id: 'redhat-developer/web-terminal/latest'|id: 'redhat-developer/web-terminal-dev/latest'|" \
+             -e '/       name: .web-terminal-exec./{n;n;
+                  a\      components: [{name: "web-terminal-exec",container: {command: ["/go/bin/che-machine-exec","--authenticated-user-id","$(DEVWORKSPACE_CREATOR)","--idle-timeout","$(WEB_TERMINAL_IDLE_TIMEOUT)","--pod-selector","controller.devfile.io/devworkspace_id=$(DEVWORKSPACE_ID)","--use-bearer-token",]}}],
+                }' \
       $PWD/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
   rm $PWD/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts.bak
   git --no-pager diff $PWD/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts


### PR DESCRIPTION
### What does this PR do?
Fixes the `webterminal-localhost.sh` script to make testing the OpenShift Console side of the Web Terminal Operator functionality easier. Required changes:

* Kubernetes 1.22 and up no longer stores serviceaccount tokens in secrets by default. To work around this, we read the serviceaccount token from the pod directly when emulating in-cluster functionality
* The `sed` replacements for patching the Console frontend/backend were out of date; on the frontend we can no longer rely on the web-terminal-dev plugin, and instead have to disable TLS directly in the existing web-terminal-exec plugin via overrides. On the backend, we need to be careful about managing the URL to handle `https` and the path added for basic routing
    * Thing I was stuck on forever: if you try to POST to a route that uses `insecureEdgeTerminationPolicy: Redirect`, your POST will be converted into a GET by the client-go library.
* Clean up shellcheck warnings in the script.

### What issues does this PR fix or reference?
Make it possible to use `webterminal-localhost.sh` to test the full WTO flow with debugging.

### Is it tested? How?
Tested by running the script.
