### PR TITLE
Set version to v1.6.0-dev in preparation for 1.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 1.5.1
+- Base images for web terminal components have been updated:
+  - The builder image for the web-terminal-exec container was updated to use Go 1.17
+  - The Web Terminal controller now is built off of UBI 8.6
+
 #### 1.5
 - Web Terminals now show a welcome message and have a "help" command
 - New `wtoctl` utility added to make configuring image and idle timeout in Web Terminal instance easier

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-operators
     repository: https://github.com/redhat-developer/web-terminal-operator/
     support: Red Hat, Inc.
-  name: web-terminal.v1.5.0
+  name: web-terminal.v1.6.0-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -140,5 +140,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: web-terminal.v1.4.0
-  version: 1.5.0
+  replaces: web-terminal.v1.5.1
+  version: 1.6.0-dev


### PR DESCRIPTION
### What does this PR do?
Sets up the repo to have current version `v1.6.0-dev`.

### What issues does this PR fix or reference?
I've created a [release branch for the 1.5.x stream](https://github.com/redhat-developer/web-terminal-operator/tree/1.5.x), so it makes sense to set the version to 1.6.0-dev in main

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
