### PR TITLE
Increase tooling container memory limit to 512Mi

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -20,7 +20,7 @@ const (
 	ExecTemplateName    = "web-terminal-exec"
 
 	ToolingMemoryRequest = "128Mi"
-	ToolingMemoryLimit   = "256Mi"
+	ToolingMemoryLimit   = "512Mi"
 	ToolingCPURequest    = "100m"
 	ToolingCPULimit      = "400m"
 


### PR DESCRIPTION
### What does this PR do?
Increases the default memory limit for the web terminal tooling container to `512Mi`

### What issues does this PR fix or reference?
Resolves https://issues.redhat.com/browse/WTO-176

### Is it tested? How?
Install updated operator and verify that `web-terminal-tooling` DevWorkspaceTemplate is created with a memory limit of `512Mi`