### PR TITLE
Update images in templates even if state is unmanaged

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,12 +77,6 @@ install: _print_vars register_catalogsource
 
 ### uninstall: uninstalls the Web Terminal Operator Subscription and related ClusterServiceVersion
 uninstall:
-	kubectl delete subscriptions.operators.coreos.com web-terminal -n openshift-operators --ignore-not-found
-	export WTO_CSV=$$(kubectl get csv -o=json | jq -r '[.items[] | select (.metadata.name | contains("web-terminal.v1"))][0].metadata.name') ;\
-		kubectl delete csv $${WTO_CSV} -n openshift-operators
-
-### uninstall_v1_2: uninstalls the Web Terminal Operator 1.2 in the proper way described in documentation
-uninstall_v1_2:
 	# 1. Ensure that all DevWorkspace Custom Resources are removed to avoid issues with finalizers
 	# make sure depending objects are clean up as well
 	kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait
@@ -125,11 +119,11 @@ endif
 ### help: print this message
 help: Makefile
 	echo 'Available rules:'
-	sed -n 's/^### /    /p' $< | awk 'BEGIN { FS=":" } { printf "%-34s -%s\n", $$1, $$2 }'
+	sed -n 's/^### /    /p' $(MAKEFILE_LIST) | awk 'BEGIN { FS=":" } { printf "%-34s -%s\n", $$1, $$2 }'
 	echo ''
 	echo 'Supported environment variables:'
+	echo '    WTO_IMG                        - The name of the controller image. Set to $(WTO_IMG)'
 	echo '    BUNDLE_IMG                     - The name of the olm registry bundle image. Set to $(BUNDLE_IMG)'
 	echo '    INDEX_IMG                      - The name of the olm registry index image. Set to $(INDEX_IMG)'
-	echo '    DEVWORKSPACE_API_VERSION       - Branch or tag of the github.com/devfile/kubernetes-api to depend on.'
-	echo '    DEVWORKSPACE_OPERATOR_VERSION  - The branch/tag of the terminal manifests.'
+	echo '    DOCKER                         - Container build tool to use for building containers (e.g. podman, docker). Set to $(DOCKER)'
 	echo '    GET_DIGEST_WITH                - The tool name for obtaining an image didgest. Supported tools: skopeo, podman, docker'

--- a/pkg/webterminal/exec.go
+++ b/pkg/webterminal/exec.go
@@ -15,6 +15,7 @@ package webterminal
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/api/v2/pkg/attributes"
@@ -41,18 +42,64 @@ func syncExecTemplate(ctx context.Context, client crclient.Client, namespace str
 		return client.Create(ctx, specDWT)
 	}
 
+	var updatedDWT *dw.DevWorkspaceTemplate
 	if clusterDWT.Annotations != nil && clusterDWT.Annotations[config.UnmanagedStateAnnotation] == "true" {
-		log.Info("Found unmanaged template for Web Terminal Exec; skipping.")
-		return nil
+		log.Info("Found unmanaged template for Web Terminal Exec.")
+		updatedDWT = handleUnmanagedExecState(specDWT, clusterDWT)
+	} else {
+		specDWT.ResourceVersion = clusterDWT.ResourceVersion
+		updatedDWT = specDWT
 	}
 
-	specDWT.ResourceVersion = clusterDWT.ResourceVersion
-	err = client.Update(ctx, specDWT)
+	err = client.Update(ctx, updatedDWT)
 	if err != nil {
 		return fmt.Errorf("error updating Web Terminal Exec template: %w", err)
 	}
 	log.Info("Web Terminal Exec template updated.")
 	return nil
+}
+
+func handleUnmanagedExecState(spec, cluster *dw.DevWorkspaceTemplate) *dw.DevWorkspaceTemplate {
+	result := cluster.DeepCopy()
+
+	// Even though the template is marked as unmanaged, still try to update the image used if the current
+	// image is a default image to ensure CVE fixes are propagated
+	specImage, err := config.GetDefaultExecImage()
+	if err != nil {
+		// Should never happen, since getSpecExecTemplate depends on the same function
+		log.Info("warning: Could not get default Web Terminal Exec container image")
+		return cluster
+	}
+	var clusterImage string
+	for _, component := range cluster.Spec.Components {
+		if component.Name == config.ExecTemplateName && component.Container != nil {
+			clusterImage = component.Container.Image
+		}
+	}
+	if specImage == clusterImage {
+		// No update needed
+		return cluster
+	}
+
+	if clusterImage == "" {
+		// The cluster template is potentially _very_ different from default; do the safe thing and make no changes
+		return cluster
+	}
+	// Strip digest or tag from images
+	specRepo := strings.Split(specImage, `@`)[0]
+	specRepo = strings.Split(specRepo, `:`)[0]
+	clusterRepo := strings.Split(clusterImage, `@`)[0]
+	clusterRepo = strings.Split(clusterRepo, `:`)[0]
+	if specRepo == clusterRepo {
+		log.Info(fmt.Sprintf("Found default image %s in Web Terminal Exec template. Updating image to %s", clusterImage, specImage))
+		for idx, component := range result.Spec.Components {
+			if component.Name == config.ExecTemplateName {
+				result.Spec.Components[idx].Container.Image = specImage
+			}
+		}
+	}
+
+	return result
 }
 
 func getSpecExecTemplate(namespace string) (*dw.DevWorkspaceTemplate, error) {

--- a/pkg/webterminal/tooling.go
+++ b/pkg/webterminal/tooling.go
@@ -15,6 +15,7 @@ package webterminal
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,18 +41,64 @@ func syncToolingTemplate(ctx context.Context, client crclient.Client, namespace 
 		return client.Create(ctx, specDWT)
 	}
 
+	var updatedDWT *dw.DevWorkspaceTemplate
 	if clusterDWT.Annotations != nil && clusterDWT.Annotations[config.UnmanagedStateAnnotation] == "true" {
-		log.Info("Found unmanaged template for Web Terminal Tooling; skipping.")
-		return nil
+		log.Info("Found unmanaged template for Web Terminal Tooling.")
+		updatedDWT = handleUnmanagedToolingState(specDWT, clusterDWT)
+	} else {
+		specDWT.ResourceVersion = clusterDWT.ResourceVersion
+		updatedDWT = specDWT
 	}
 
-	specDWT.ResourceVersion = clusterDWT.ResourceVersion
-	err = client.Update(ctx, specDWT)
+	err = client.Update(ctx, updatedDWT)
 	if err != nil {
 		return fmt.Errorf("error updating Web Terminal Tooling template: %w", err)
 	}
 	log.Info("Web Terminal Tooling template updated.")
 	return nil
+}
+
+func handleUnmanagedToolingState(spec, cluster *dw.DevWorkspaceTemplate) *dw.DevWorkspaceTemplate {
+	result := cluster.DeepCopy()
+
+	// Even though the template is marked as unmanaged, still try to update the image used if the current
+	// image is a default image to ensure CVE fixes are propagated
+	specImage, err := config.GetDefaultToolingImage()
+	if err != nil {
+		// Should never happen, since getSpecToolingTemplate depends on the same function
+		log.Info("warning: Could not get default Web Terminal Tooling container image")
+		return cluster
+	}
+	var clusterImage string
+	for _, component := range cluster.Spec.Components {
+		if component.Name == config.ToolingTemplateName && component.Container != nil {
+			clusterImage = component.Container.Image
+		}
+	}
+	if specImage == clusterImage {
+		// No update needed
+		return cluster
+	}
+
+	if clusterImage == "" {
+		// The cluster template is potentially _very_ different from default; do the safe thing and make no changes
+		return cluster
+	}
+	// Strip digest or tag from images
+	specRepo := strings.Split(specImage, `@`)[0]
+	specRepo = strings.Split(specRepo, `:`)[0]
+	clusterRepo := strings.Split(clusterImage, `@`)[0]
+	clusterRepo = strings.Split(clusterRepo, `:`)[0]
+	if specRepo == clusterRepo {
+		log.Info(fmt.Sprintf("Found default image %s in Web Terminal Tooling template. Updating image to %s", clusterImage, specImage))
+		for idx, component := range result.Spec.Components {
+			if component.Name == config.ToolingTemplateName {
+				result.Spec.Components[idx].Container.Image = specImage
+			}
+		}
+	}
+
+	return result
 }
 
 func getSpecToolingTemplate(namespace string) (*dw.DevWorkspaceTemplate, error) {


### PR DESCRIPTION
### What does this PR do?
Updates images for templates with `web-terminal.redhat.com/unmanaged-state: "true"` if the image in the template comes from the default image repository.

This ensures that fixes/updates are still applied to WTO installs in clusters even if an admin has decided to e.g. modify resource requests/limits.

If the image in the template comes from another repository (e.g. a custom-built tooling image) no changes are made.

Also updates the Makefile:
* Drop some environment variables we no longer use
* Fix `make help` not printing all available rules

### What issues does this PR fix or reference?
Resolves https://issues.redhat.com/browse/WTO-209

### Is it tested? How?
To test:
1. Install Web Terminal Operator in a cluster
2. Update `web-terminal-tooling` and `web-terminal-exec` DevWorkspaceTemplates to have `web-terminal.redhat.com/unmanaged-state: "true"` annotation, and change image to e.g. the `1.7` tag instead of the default digest value
3. Update the WTO CSV to set the operator's image to `quay.io/amisevsk/web-terminal-operator:update-unmanaged`
4. Verify (in logs and in dwts) that images are updated back to the current digest for tooling/exec when controller container restarts.
