### PR TITLE
Prepare for WTO 1.10 release

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20.10
+        go-version: 1.20.12
     -
       name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+#### 1.10
+- Default tooling versions have been updated:
+  - oc v4.14.5 -> v4.15.0
+  - kubectl v1.27.4 -> 1.28.2
+  - kustomize v5.2.1 -> v5.3.0
+  - odo v3.15.0 -> v3.15.0
+  - helm v3.12.1 -> v3.12.1
+  - knative v1.9.2 -> v1.10.0
+  - tekton v0.33.0 -> v0.35.1
+  - rhoas v0.53.0 -> v0.53.0
+  - submariner v0.16.2 -> v0.17.0
+  - virtctl v1.1.0 -> v1.2.0
+
 #### 1.9
 - The wtoctl utility now supports adding persistent storage to existing Web Terminal instances (see `wtoctl storage --help`).
 - The Web Terminal operator will update images in DevWorkspaceTemplates (`web-terminal-tooling` and `web-terminal-exec`) if they are in an unmanaged state but the image has not been changed. This allows customizing Web Terminal defaults while still receiving updated images.

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -20,7 +20,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports (i.e. which version of oc is installed).
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="v4.14"
+LABEL com.redhat.openshift.versions="v4.15"
 
 # The rest of these labels are copies of the same content in annotations.yaml and are needed by OLM
 # Note the package name and channels which are very important!

--- a/build/dockerfiles/controller.Dockerfile
+++ b/build/dockerfiles/controller.Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.20.10-3 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20.12-2 as builder
 ENV GOPATH=/go/
 USER root
 
@@ -30,7 +30,7 @@ COPY . .
 RUN make compile
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.9-1029
+FROM registry.access.redhat.com/ubi8-minimal:8.9-1137
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /web-terminal-operator/_output/bin/web-terminal-controller /usr/local/bin/web-terminal-controller

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-operators
     repository: https://github.com/redhat-developer/web-terminal-operator/
     support: Red Hat, Inc.
-  name: web-terminal.v1.9.0
+  name: web-terminal.v1.10.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -137,5 +137,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: web-terminal.v1.8.0
-  version: 1.9.0
+  replaces: web-terminal.v1.9.0
+  version: 1.10.0


### PR DESCRIPTION
### What does this PR do?
- Updates the changelog, refer to https://github.com/redhat-developer/web-terminal-tooling/pull/69 for tooling version updates
- Updates CSV version to WTO 1.10
- Updates base images for controller build
- Updates minimum OpenShift version annotation to OpenShift 4.15

### Is it tested? How?
Testing requires an OpenShift 4.15 cluster.

I've built the controller, index and bundle images from this PR and pushed them to `quay.io/aobuchow/wto-controller:1.10`, `quay.io/aobuchow/wto-bundle:1.10` & `quay.io/aobuchow/wto-index:1.10` respectively.

The accompanying WTO tooling image (built from this [PR](https://github.com/redhat-developer/web-terminal-tooling/pull/69)) has also been pushed to `quay.io/aobuchow/wto-tooling:1.10`.

To test the images, set the `WTO_IMG`,  `BUNDLE_IMG` & `INDEX_IMG` environment variables to the above-mentioned repos, i.e:
```
export WTO_IMG=quay.io/aobuchow/wto-controller:1.10 && export BUNDLE_IMG=quay.io/aobuchow/wto-bundle:1.10 && export INDEX_IMG=quay.io/aobuchow/wto-index:1.10
```
Then run `make install` from the root of this repo. 

WTO 1.10 should be installed (and viewable on the Installed Operators page of the OpenShift console) using the images built from this PR.

**Note:** Running the version of WTO installed will still be using `quay.io/wto/web-terminal-operator:next` instead of the image built from this PR, set to `WTO_IMG`. To actually test out the controller image, find the web-terminal-operator clusterserviceversion in the `openshift-operators` namespace, and modify the `spec.containers.image` field to use the controller image built from this PR. E.g.:

```diff
apiVersion: operators.coreos.com/v1alpha1
kind: ClusterServiceVersion
(...)
spec:
(...)
  install:
    spec:
      deployments:
        - name: web-terminal-controller
          spec:
(...)
              spec:
                containers:
                  - env:
                      - name: POD_NAME
                        valueFrom:
                          fieldRef:
                            fieldPath: metadata.name
                      - name: OPERATOR_NAME
                        value: web-terminal-operator
                      - name: RELATED_IMAGE_web_terminal_tooling
                        value: 'quay.io/wto/web-terminal-tooling:latest'
                      - name: RELATED_IMAGE_web_terminal_exec
                        value: 'quay.io/eclipse/che-machine-exec:nightly'
-                   image: 'quay.io/wto/web-terminal-operator:next'
+                   image: 'quay.io/aobuchow/wto-controller:1.10'
                    imagePullPolicy: Always
                    name: web-terminal-controller
                    resources: {}
                serviceAccountName: web-terminal-controller
```

The web-terminal-controller deployment should spawn a new pod with the updated container, and you should be able to create web terminals.

A future PR could automate this process of updating the CSV for testing the controller image (as this confused me a bit while working on this PR).
