### PR TITLE
Add kubeadmin terminal creation bug to known issues for 1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 #### 1.10
+- **Known issues:**
+  - There is a [known issue](https://github.com/redhat-developer/web-terminal-operator/issues/162) where users logged in to an OpenShift 4.15 (or higher) cluster as `kubeadmin` are unable to create web terminals. The error message shown is `"Error Loading OpenShift command line terminal: User is not a owner of the requested workspace"`. Regular OpenShift cluster users are unaffected.
 - Default tooling versions have been updated:
   - oc v4.14.5 -> v4.15.0
   - kubectl v1.27.4 -> 1.28.2


### PR DESCRIPTION
### What does this PR do?
Adds a note to the 1.10 release notes/changelog about https://github.com/redhat-developer/web-terminal-operator/issues/162 so that users can easily find the relevant bug and see if it has been resolved.

### What issues does this PR fix or reference?
Part of https://github.com/redhat-developer/web-terminal-operator/issues/162 & 1.10 release process

### Is it tested? How?
n/a, documentation change