### PR TITLE
Prepare for WTO 1.11 release

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20.12
+        go-version: 1.21.10
     -
       name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+#### 1.11
+- All container images used in the Web Terminal Operator have been migrated from UBI8 to UBI9 based images.
+- Default tooling versions have been updated:
+  - oc v4.15.0 -> v4.16.0
+  - kubectl v1.28.2 -> 1.29.1
+  - kustomize v5.3.0 -> v5.4.2
+  - odo v3.15.0 -> v3.16.1
+  - helm v3.12.1 -> v3.14.4
+  - knative v1.11.2 -> v1.12.0
+  - tekton v0.35.1 -> v0.37.0
+  - rhoas v0.53.0 -> v0.53.0
+  - submariner v0.17.0 -> v0.17.2
+  - virtctl v1.2.0 -> v1.2.2
+
 #### 1.10
 - **Known issues:**
   - There is a [known issue](https://github.com/redhat-developer/web-terminal-operator/issues/162) where users logged in to an OpenShift 4.15 (or higher) cluster as `kubeadmin` are unable to create web terminals. The error message shown is `"Error Loading OpenShift command line terminal: User is not a owner of the requested workspace"`. Regular OpenShift cluster users are unaffected.
@@ -7,7 +21,7 @@
   - kustomize v5.2.1 -> v5.3.0
   - odo v3.15.0 -> v3.15.0
   - helm v3.12.1 -> v3.12.1
-  - knative v1.9.2 -> v1.10.0
+  - knative v1.9.2 -> v1.11.2
   - tekton v0.33.0 -> v0.35.1
   - rhoas v0.53.0 -> v0.53.0
   - submariner v0.16.2 -> v0.17.0

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -20,7 +20,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports (i.e. which version of oc is installed).
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="v4.15"
+LABEL com.redhat.openshift.versions="v4.16"
 
 # The rest of these labels are copies of the same content in annotations.yaml and are needed by OLM
 # Note the package name and channels which are very important!

--- a/build/dockerfiles/controller.Dockerfile
+++ b/build/dockerfiles/controller.Dockerfile
@@ -9,8 +9,8 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.20.12-2 as builder
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21.10-1.1719562237 AS builder
 ENV GOPATH=/go/
 USER root
 
@@ -29,8 +29,8 @@ COPY . .
 # compile terminal controller binary
 RUN make compile
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.9-1137
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1134
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /web-terminal-operator/_output/bin/web-terminal-controller /usr/local/bin/web-terminal-controller

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-operators
     repository: https://github.com/redhat-developer/web-terminal-operator/
     support: Red Hat, Inc.
-  name: web-terminal.v1.10.0
+  name: web-terminal.v1.11.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -137,5 +137,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: web-terminal.v1.9.0
-  version: 1.10.0
+  replaces: web-terminal.v1.10.0
+  version: 1.11.0


### PR DESCRIPTION
### What does this PR do?
- Update changelog, refer to https://github.com/redhat-developer/web-terminal-tooling/pull/71 for tooling version updates
- Update CSV version to WTO 1.11
- Update base images for controller build to UBI9
- Updates minimum OpenShift version annotation to OpenShift 4.16

### What issues does this PR fix or reference?
n/a

### Is it tested? How?
Testing requires an OpenShift 4.16+ cluster. I recommend OpenShift 4.17, since the [backport to fix using kubeadmin with WTO](https://github.com/redhat-developer/web-terminal-operator/issues/162#issuecomment-2206400246) has not been merged to OpenShift 4.16 yet. 

From the root of this repo, you should be able to set the appropriate environment variables to point to your quay repo's and install WTO built from this PR:

```bash
# Setup Environment Variables
export WTO_IMG=quay.io/<user>/wto-controller:1.11 && \
export INDEX_IMG=quay.io/<user>/wto-index:1.11 && \
export BUNDLE_IMG=quay.io/<user>/wto-bundle:1.11

# Build custom index 
make build_custom_iib_image

# Register custom catalogsource 
make register_catalogsource 
```

WTO 1.11 should be installed (and viewable on the Installed Operators page of the OpenShift console) using the images built from this PR.

You should be able to create web terminals as expected. Once you've gotten to this point, I recommend reviewing the associated [WTO 1.11 tooling PR](https://github.com/redhat-developer/web-terminal-tooling/pull/71)

