### PR TITLE
Mention removal of odo cli from 1.11 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 #### 1.11
 - All container images used in the Web Terminal Operator have been migrated from UBI8 to UBI9 based images.
+- odo has been removed from the Web Terminal tooling container image as it does not currently support UBI9 based images. See [WTO-298](https://issues.redhat.com/browse/WTO-298) for more information.
 - Default tooling versions have been updated:
   - oc v4.15.0 -> v4.16.0
   - kubectl v1.28.2 -> 1.29.1
   - kustomize v5.3.0 -> v5.4.2
-  - odo v3.15.0 -> v3.16.1
   - helm v3.12.1 -> v3.14.4
   - knative v1.11.2 -> v1.12.0
   - tekton v0.35.1 -> v0.37.0


### PR DESCRIPTION
### What does this PR do?
Mentions the removal of the odo CLI from the web terminal tooling image. 

odo does not currently support RHEL9 (and consequently, UBI9) based images. Since WTO 1.11 is based on UBI9, we are removing odo from the tooling image for the time being (see https://github.com/redhat-developer/web-terminal-tooling/pull/72).

odo can still be added to a custom web terminal tooling image by users if desired, see https://issues.redhat.com/browse/WTO-298 for more details.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/WTO-298

### Is it tested? How?
n/a
