### PR TITLE
Prepare for WTO 1.12 release 

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.21.10
+        go-version: 1.21.13
     -
       name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+#### 1.12
+- Default tooling versions have been updated:
+  - oc v4.16.0 -> v4.17.0
+  - kubectl 1.29.1 -> 1.30.2
+  - kustomize v5.4.2 -> v5.5.0
+  - helm v3.14.4 -> v3.14.4
+  - knative v1.12.0 -> v1.12.0
+  - tekton v0.37.0 -> v0.38.1
+  - rhoas v0.53.0 -> v0.53.0
+  - submariner v0.17.2 -> v0.18.1
+  - virtctl v1.2.2 -> v1.3.1
+
 #### 1.11
 - All container images used in the Web Terminal Operator have been migrated from UBI8 to UBI9 based images.
 - odo has been removed from the Web Terminal tooling container image as it does not currently support UBI9 based images. See [WTO-298](https://issues.redhat.com/browse/WTO-298) for more information.

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -20,7 +20,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports (i.e. which version of oc is installed).
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="v4.16"
+LABEL com.redhat.openshift.versions="v4.17"
 
 # The rest of these labels are copies of the same content in annotations.yaml and are needed by OLM
 # Note the package name and channels which are very important!

--- a/build/dockerfiles/controller.Dockerfile
+++ b/build/dockerfiles/controller.Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21.10-1.1719562237 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21.13-2.1727893526 AS builder
 ENV GOPATH=/go/
 USER root
 
@@ -30,7 +30,7 @@ COPY . .
 RUN make compile
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9-minimal
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1134
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227.1726694542
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /web-terminal-operator/_output/bin/web-terminal-controller /usr/local/bin/web-terminal-controller

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-operators
     repository: https://github.com/redhat-developer/web-terminal-operator/
     support: Red Hat, Inc.
-  name: web-terminal.v1.11.0
+  name: web-terminal.v1.12.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -137,5 +137,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: web-terminal.v1.10.0
-  version: 1.11.0
+  replaces: web-terminal.v1.11.0
+  version: 1.12.0


### PR DESCRIPTION
### What does this PR do?
- Update changelog, refer to https://github.com/redhat-developer/web-terminal-tooling/pull/73 for tooling version updates
- Update CSV version to WTO 1.12
- Update base images used in controller Dockerfile 
- Updates minimum OpenShift version annotation to OpenShift 4.17
- Bumps go version in pr-check workflow to go v1.21.13

### What issues does this PR fix or reference?
n/a

### Is it tested? How?
Testing requires an OpenShift 4.17+ cluster.

From the root of this repo, you should be able to set the appropriate environment variables to point to your quay repo's and install WTO built from this PR:

```bash
# Setup Environment Variables
export WTO_IMG=quay.io/<user>/wto-controller:1.12 && \
export INDEX_IMG=quay.io/<user>/wto-index:1.12 && \
export BUNDLE_IMG=quay.io/<user>/wto-bundle:1.12

# Build custom index 
make build_custom_iib_image

# Register custom catalogsource 
make register_catalogsource 
```

WTO 1.12 should be installed (and viewable on the Installed Operators page of the OpenShift console) using the images built from this PR.

You should be able to create web terminals as expected. Once you've gotten to this point, I recommend reviewing the associated [WTO 1.12 tooling PR](https://github.com/redhat-developer/web-terminal-tooling/pull/73)
