### PR TITLE
Update go 1.23

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.21.13
+        go-version: 1.23.6
     -
       name: Check out code into the Go module directory
       uses: actions/checkout@v4

--- a/build/dockerfiles/controller.Dockerfile
+++ b/build/dockerfiles/controller.Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21.13-2.1727893526 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1745328278 AS builder
 ENV GOPATH=/go/
 USER root
 

--- a/build/scripts/build_index_image.sh
+++ b/build/scripts/build_index_image.sh
@@ -62,7 +62,7 @@ $PODMAN build -f ./build/dockerfiles/Dockerfile -t "$BUNDLE_IMAGE" .
 $PODMAN push "$BUNDLE_IMAGE"
 
 # Get digest for bundle image we just built
-BUNDLE_DIGEST=$($PODMAN inspect "$BUNDLE_IMAGE" | jq ".[].RepoDigests[0]" -r)
+BUNDLE_DIGEST=$(skopeo inspect "docker://$BUNDLE_IMAGE" | jq '"\(.Name)@\(.Digest)"' -r)
 echo "Using bundle $BUNDLE_DIGEST in index"
 
 set -x

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/redhat-developer/web-terminal-operator
 
-go 1.20
+go 1.23
+
+toolchain go1.23.0
 
 require (
 	github.com/devfile/api/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -604,6 +604,7 @@ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
+golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
### What does this PR do?
* Updates project to use go version 1.23
* Uses skopeo to get the image digest when building index image, instead of podman

### What issues does this PR fix or reference?
https://github.com/redhat-developer/web-terminal-operator/issues/178

The `golang.org/x/net` dependency is quite outdated for this repository: https://github.com/redhat-developer/web-terminal-operator/blob/b135f1a2642cce856c6bf40d6abc2431ba505e67/go.mod#L42

The version of go needs to be updated to 1.23 to merge this update: https://github.com/redhat-developer/web-terminal-operator/pull/179.

Version `golang.org/x/net` 0.23 is susceptible to this CVE: https://access.redhat.com/security/cve/cve-2024-45338

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

After logging into an OpenShift cluster, run:
```
# Setup Environment Variables
export WTO_IMG=quay.io/<user>/wto-controller:next && \
export INDEX_IMG=quay.io/<user>/wto-index:next && \
export BUNDLE_IMG=quay.io/<user>/wto-bundle:next

# Build custom index 
make build_custom_iib_image

# Register custom catalogsource 
make register_catalogsource 
```

and install WTO from OperatorHub.

Verify that the WTO is working as expected:
![image](https://github.com/user-attachments/assets/9612b3bf-7cd7-4819-ac84-600b5dfc1499)
