### PR TITLE
Prepare for WTO 1.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+#### 1.13
+- Default tooling versions have been updated:
+  - oc v4.17.0 -> v4.18.11
+  - kubectl 1.30.2 -> 1.31.1
+  - kustomize v5.5.0 -> v5.6.0
+  - helm v3.14.4 -> v3.15.4
+  - knative v1.12.0 -> v1.15.0-4
+  - tekton v0.38.1 -> v0.40.0
+  - rhoas v0.53.0 -> v0.53.0
+  - submariner v0.18.1 -> v0.20.0
+  - virtctl v1.3.1 -> v1.5.0
+
 #### 1.12
 - Default tooling versions have been updated:
   - oc v4.16.0 -> v4.17.0

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -20,7 +20,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports (i.e. which version of oc is installed).
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="v4.17"
+LABEL com.redhat.openshift.versions="v4.18"
 
 # The rest of these labels are copies of the same content in annotations.yaml and are needed by OLM
 # Note the package name and channels which are very important!

--- a/build/dockerfiles/controller.Dockerfile
+++ b/build/dockerfiles/controller.Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1745328278 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1745588370 AS builder
 ENV GOPATH=/go/
 USER root
 
@@ -30,7 +30,7 @@ COPY . .
 RUN make compile
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9-minimal
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227.1726694542
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1747218906
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /web-terminal-operator/_output/bin/web-terminal-controller /usr/local/bin/web-terminal-controller

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-operators
     repository: https://github.com/redhat-developer/web-terminal-operator/
     support: Red Hat, Inc.
-  name: web-terminal.v1.12.0
+  name: web-terminal.v1.13.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -137,5 +137,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: web-terminal.v1.11.0
-  version: 1.12.0
+  replaces: web-terminal.v1.12.0
+  version: 1.13.0


### PR DESCRIPTION
### What does this PR do?
Updates the project for the WTO 1.13 release

Update changelog, refer to https://github.com/redhat-developer/web-terminal-tooling/pull/76 for tooling version updates
Update CSV version to WTO 1.13
Update base images used in controller Dockerfile
Updates minimum OpenShift version annotation to OpenShift 4.18

### What issues does this PR fix or reference?


### Is it tested? How?
Testing requires an OpenShift 4.18+ cluster.

From the root of this repo, set the appropriate environment variables to point to your quay repo's and install WTO built from this PR:
```
# Setup Environment Variables
export WTO_IMG=quay.io/<user>/wto-controller:1.13 && \
export INDEX_IMG=quay.io/<user>/wto-index:1.13 && \
export BUNDLE_IMG=quay.io/<user>/wto-bundle:1.13

# Build custom index 
make build_custom_iib_image

# Register custom catalogsource 
make register_catalogsource 
```

WTO 1.13 should be installed (and viewable on the Installed Operators page of the OpenShift console) using the images built from this PR.

The terminal should work as expected: TODO
