### PR TITLE
chore : add a devfile for using project from Cloud Develpment Environments

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -1,0 +1,79 @@
+#
+# Copyright (c) 2020-2024 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+schemaVersion: 2.3.0
+metadata:
+  name: web-terminal-operator
+components:
+  - name: tools
+    container:
+      image: quay.io/wto/web-terminal-operator-devtools:latest
+      memoryRequest: 1Gi
+      memoryLimit: 16Gi
+      cpuLimit: '4'
+      cpuRequest: '0.5'
+      env:
+        - name: DOCKER
+          value: podman
+commands:
+  - id: build-and-push-controller
+    exec:
+      label: "1. Build and push WTO controller image"
+      component: tools
+      commandLine: |
+        read -p "ENTER a container registry org to push the web-terminal-operator images (e.g. quay.io/janedoe): " WTO_IMG_REPO &&
+        read -p "ENTER the tag for the image (e.g. dev): " WTO_IMG_TAG &&
+        export WTO_IMG=${WTO_IMG_REPO}/web-terminal-operator:${WTO_IMG_TAG} &&
+        export BUNDLE_IMG=${WTO_IMG_REPO}/web-terminal-operator-metadata:${WTO_IMG_TAG} &&
+        export INDEX_IMG=${WTO_IMG_REPO}/web-terminal-operator-index:${WTO_IMG_TAG} &&
+        make build
+      group:
+        kind: build
+  - id: install-operator
+    exec:
+      label: "2. Register CatalogSource and install the operator"
+      component: tools
+      commandLine: |
+        read -p "ENTER a container registry org to use the web-terminal-operator images (e.g. quay.io/janedoe): " WTO_IMG_REPO &&
+        read -p "ENTER the tag for the image (e.g. dev): " WTO_IMG_TAG &&
+        export WTO_IMG=${WTO_IMG_REPO}/web-terminal-operator:${WTO_IMG_TAG} &&
+        export BUNDLE_IMG=${WTO_IMG_REPO}/web-terminal-operator-metadata:${WTO_IMG_TAG} &&
+        export INDEX_IMG=${WTO_IMG_REPO}/web-terminal-operator-index:${WTO_IMG_TAG} &&
+        make install
+      group:
+        kind: run
+
+  - id: register-catalogsource
+    exec:
+      label: "3. Register CatalogSource only"
+      component: tools
+      commandLine: |
+        read -p "ENTER a container registry org to push the web-terminal-operator images (e.g. quay.io/janedoe): " WTO_IMG_REPO &&
+        read -p "ENTER the tag for the image (e.g. dev): " WTO_IMG_TAG &&
+        export WTO_IMG=${WTO_IMG_REPO}/web-terminal-operator:${WTO_IMG_TAG} &&
+        export BUNDLE_IMG=${WTO_IMG_REPO}/web-terminal-operator-metadata:${WTO_IMG_TAG} &&
+        export INDEX_IMG=${WTO_IMG_REPO}/web-terminal-operator-index:${WTO_IMG_TAG} &&
+        make register_catalogsource
+      group:
+        kind: run
+
+  - id: unregister-catalogsource
+    exec:
+      label: "4. Unregister CatalogSource"
+      component: tools
+      commandLine: make unregister_catalogsource
+      group:
+        kind: run
+
+  - id: uninstall-operator
+    exec:
+      label: "5. Uninstall the Web Terminal Operator"
+      component: tools
+      commandLine: make uninstall
+      group:
+        kind: run

--- a/.github/workflows/devtools-image-build.yml
+++ b/.github/workflows/devtools-image-build.yml
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2020-2024 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Devtools container build
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  PUSH_REGISTRY: quay.io
+
+jobs:
+  build-devtools-img:
+    runs-on: ubuntu-24.04
+    outputs:
+      git-sha: ${{ steps.git-sha.outputs.sha }}
+
+    steps:
+      - name: Checkout webterminal-operator source code
+        uses: actions/checkout@v4
+
+      - name: Set output for Git short SHA
+        id: git-sha
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Login to quay.io
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: ${{ env.PUSH_REGISTRY }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push webterminal-operator-devtools image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.PUSH_REGISTRY }}/${{ secrets.QUAY_USERNAME }}/web-terminal-operator-devtools:latest
+            ${{ env.PUSH_REGISTRY }}/${{ secrets.QUAY_USERNAME }}/web-terminal-operator-devtools:sha-${{ steps.git-sha.outputs.sha }}
+          file: ./build/dockerfiles/devtools.Dockerfile
+

--- a/Makefile
+++ b/Makefile
@@ -100,22 +100,19 @@ uninstall:
 	# 1. Ensure that all DevWorkspace Custom Resources are removed to avoid issues with finalizers
 	# make sure depending objects are clean up as well
 	kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait
-	kubectl delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
-	kubectl delete components.controller.devfile.io --all-namespaces --all --wait
+	kubectl delete devworkspaceroutings.controller.devfile.io --all-namespaces --all --wait
 	# 2. Uninstall the Operator
 	kubectl delete subscriptions.operators.coreos.com web-terminal -n openshift-operators --ignore-not-found
 	$(eval WTO_CSV := $(shell kubectl get csv -o=json | jq -r '[.items[] | select (.metadata.name | contains("web-terminal.v1"))][0].metadata.name'))
 	kubectl delete csv ${WTO_CSV} -n openshift-operators
 	# 3. Remove CRDs
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaceroutings.controller.devfile.io
 	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io
 	# 4. Remove DevWorkspace Webhook Server Deployment itself
 	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators
 	# 5. Remove lingering service, secrets, and configmaps
 	kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
 	kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators
-	kubectl delete configmap devworkspace-controller -n openshift-operators
 	kubectl delete clusterrole devworkspace-webhook-server
 	kubectl delete clusterrolebinding devworkspace-webhook-server
 	# 6. Remove mutating/validating webhooks configuration

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ This repo includes a `Makefile` to simplify deploying the Operator to a cluster:
 | `make register_catalogsource` | Register the CatalogSource but do not install the operator. This enables the operator to be installed manually through OperatorHub. |
 | `make unregister_catalogsource` | Remove the CatalogSource from the cluster. |
 | `make uninstall` | uninstalls the Web Terminal Operator Subscription and related ClusterServiceVersion |
-| `make uninstall_v1_2` | Remove the installed WTO 1.2 from the cluster |
 
 The commands above require being logged in to the cluster as a `cluster-admin`. See `make help` for a full list of supported environment variables and rules available.
 

--- a/build/dockerfiles/devtools.Dockerfile
+++ b/build/dockerfiles/devtools.Dockerfile
@@ -1,0 +1,38 @@
+# Copyright (c) 2021-2024 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+FROM quay.io/devfile/base-developer-image:ubi9-latest
+
+USER root
+
+# Install gettext
+RUN dnf install -y gettext make jq python3-pip && \
+    pip3 install yq
+
+# Install the Operator SDK
+ENV OPERATOR_SDK_VERSION="v0.17.2"
+ENV OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}
+RUN curl -sSLO ${OPERATOR_SDK_DL_URL}/operator-sdk_linux_amd64 && \
+    chmod +x operator-sdk_linux_amd64 && \
+    mv operator-sdk_linux_amd64 /usr/local/bin/operator-sdk
+
+# Install opm CLI
+ENV OPM_VERSION="v1.13.1"
+RUN curl -sSLO https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm && \
+    chmod +x linux-amd64-opm && \
+    mv linux-amd64-opm /usr/local/bin/opm
+
+ENV OC_VERSION=4.19
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz | \
+    tar -C /usr/local/bin -xz --no-same-owner && \
+    chmod +x /usr/local/bin/oc
+
+USER 1001
+

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -8,7 +8,7 @@ Manual steps are required to uninstall the Web Terminal Operator in order to avo
 
 	```
 	kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait
-	kubectl delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
+	kubectl delete devworkspaceroutings.controller.devfile.io --all-namespaces --all --wait
 	kubectl delete components.controller.devfile.io --all-namespaces --all --wait
 	```
 	Note: This step must be done first, as otherwise the resources above may have finalizers that block automatic cleanup.
@@ -18,7 +18,7 @@ Manual steps are required to uninstall the Web Terminal Operator in order to avo
 3. Remove the custom resource definitions installed by the operator
 
 	```
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io
+	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaceroutings.controller.devfile.io
 	kubectl delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io
 	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io
 	```


### PR DESCRIPTION
### What does this PR do?

**Update**: No need to add additional secrets, There are secrets already added in this repository that can be reused in Devtools image push workflow
~In order to make GitHub action for building and pushing tooling container image, we need to add these Secrets to GitHub Actions configuration~:
~- `PUSH_PASSWORD` : password for pusing to `quay.io/wto`~

It adds a Devfile (plus the tooling container Dockerfile and the GH to build it) that has a couple of commands to:
1. Build and push WTO controller image
2. Register CatalogSource and install the operator
3. Register CatalogSource only
4. Unregister CatalogSource
5. Uninstall the Web Terminal Operator


I was facing some issues with `make uninstall` target, I have made some modifications in Makefile : 
- I couldn't find any CustomResourceDefinition named `workspaceroutings.controller.devfile.io` , Probably it was renamed but we forgot to update it's reference. I've renamed it to `devworkspaceroutings.controller.devfile.io`
- I couldn't find any CustomResourceDefinition named `components.controller.devfile.io`, I removed step for uninstalling it
- I couldn't find any ConfigMap `devworkspace-controller` in `openshift-operators` namespace, I removed step for uninstalling it
- I couldn't find any Makefile target named `uninstall_v1_2` , I've removed it from README
### What issues does this PR fix or reference?
It's a part of https://github.com/redhat-developer/web-terminal-operator/issues/173


### Is it tested? How?
Go to Eclipse Che Dashboard and open this project https://github.com/rohankanojia-forks/web-terminal-operator

Once project is loaded, click on `Run Task` > select task: `devfile` , you would see these options:
![Screenshot_20250620_160149](https://github.com/user-attachments/assets/d8344e15-89b6-47d2-99b5-bb9e445d1107)

