### PR TITLE
Prepare for 1.14 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+#### 1.14
+- Default tooling versions have been updated:
+  - oc v4.18.11 -> v4.19.9
+  - kubectl 1.30.2 -> 1.31.1
+  - kustomize v5.6.0 -> v5.7.1
+  - helm v3.15.4 -> v3.17.1
+  - knative v1.15.0-4 -> v1.15.0-6
+  - tekton v0.40.0 -> v1.19.0
+  - rhoas v0.53.0 -> v0.53.0
+  - submariner v0.20.0 -> v0.21.0
+  - virtctl v1.5.0 -> v1.6.0
+
 #### 1.13
 - The default server timeouts for web-terminal-exec has been increased from 3 seconds to 10 seconds. See [pull request](https://github.com/redhat-developer/web-terminal-exec/pull/118) for more information.
 - Default tooling versions have been updated:

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -20,7 +20,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports (i.e. which version of oc is installed).
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="v4.18"
+LABEL com.redhat.openshift.versions="v4.19"
 
 # The rest of these labels are copies of the same content in annotations.yaml and are needed by OLM
 # Note the package name and channels which are very important!

--- a/build/dockerfiles/controller.Dockerfile
+++ b/build/dockerfiles/controller.Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1745588370 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1756993846 AS builder
 ENV GOPATH=/go/
 USER root
 
@@ -30,7 +30,7 @@ COPY . .
 RUN make compile
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9-minimal
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1747218906
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1755695350
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /web-terminal-operator/_output/bin/web-terminal-controller /usr/local/bin/web-terminal-controller

--- a/manifests/web-terminal.clusterserviceversion.yaml
+++ b/manifests/web-terminal.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-operators
     repository: https://github.com/redhat-developer/web-terminal-operator/
     support: Red Hat, Inc.
-  name: web-terminal.v1.13.0
+  name: web-terminal.v1.14.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -137,5 +137,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: web-terminal.v1.12.0
-  version: 1.13.0
+  replaces: web-terminal.v1.13.0
+  version: 1.14.0


### PR DESCRIPTION
### What does this PR do?
Updates the changelog, CSV, dockerfiles for the 1.14 release.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Testing requires an OpenShift 4.19+ cluster.

From the root of this repo, set the appropriate environment variables to point to your quay repo's and install WTO built from this PR:
```
# Setup Environment Variables
export WTO_IMG=quay.io/<user>/wto-controller:1.14 && \
export INDEX_IMG=quay.io/<user>/wto-index:1.14 && \
export BUNDLE_IMG=quay.io/<user>/wto-bundle:1.14

# Build custom index 
make build_custom_iib_image

# Register custom catalogsource 
make register_catalogsource 
```

WTO 1.14 should be installed (and viewable on the Installed Operators page of the OpenShift console) using the images built from this PR.

<img width="2222" height="824" alt="image" src="https://github.com/user-attachments/assets/76b5a321-637a-47ad-bc5b-1ea9e36f4501" />



