### PR TITLE
fix(ci): use fixed Quay namespace instead of dynamic username in image tags

### DIFF
--- a/.github/workflows/devtools-image-build.yml
+++ b/.github/workflows/devtools-image-build.yml
@@ -48,7 +48,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ env.PUSH_REGISTRY }}/${{ secrets.QUAY_USERNAME }}/web-terminal-operator-devtools:latest
-            ${{ env.PUSH_REGISTRY }}/${{ secrets.QUAY_USERNAME }}/web-terminal-operator-devtools:sha-${{ steps.git-sha.outputs.sha }}
+            ${{ env.PUSH_REGISTRY }}/wto/web-terminal-operator-devtools:latest
+            ${{ env.PUSH_REGISTRY }}/wto/web-terminal-operator-devtools:sha-${{ steps.git-sha.outputs.sha }}
           file: ./build/dockerfiles/devtools.Dockerfile
 


### PR DESCRIPTION

### What does this PR do?
Not 100% sure why but after merging devtools build workflow failed with this error https://github.com/redhat-developer/web-terminal-operator/actions/runs/17839881221/job/50726360525:
```
ERROR: failed to build: invalid tag "quay.io/***/web-terminal-operator-devtools:latest": invalid reference format
```

I suspect there is some unwanted character in it's value (possibly quotes), as same workflow is working on my fork with my username and password https://github.com/rohankanojia-forks/web-terminal-operator/actions/runs/17836441014

Replaced the use of `${{ secrets.QUAY_USERNAME }}` in Docker image tags with a
hardcoded `wto` namespace to ensure valid and predictable image references.

In other github action workflow too it's hardcoded like this:

https://github.com/redhat-developer/web-terminal-operator/blob/f96ab5f816de0d38d4e91f588b5e17c6b4811dec/.github/workflows/dockerimage-next.yml#L82-L84

### What issues does this PR fix or reference?
It tries to fix failed GitHub action execution https://github.com/redhat-developer/web-terminal-operator/actions/runs/17839881221/job/50726360525

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
