### PR TITLE
fix: remove group write permissions for /etc/passwd

### DIFF
--- a/build/bin/user_setup
+++ b/build/bin/user_setup
@@ -6,8 +6,7 @@ mkdir -p ${HOME}
 chown ${USER_UID}:0 ${HOME}
 chmod ug+rwx ${HOME}
 
-# runtime user will need to be able to self-insert in /etc/passwd
-chmod g+rw /etc/passwd
+chmod g-w /etc/passwd
 
 # no need for this script to remain in the image after running
 rm $0


### PR DESCRIPTION
### What does this PR do?
Ensures that the group does not have write permissions for /etc/passwd.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
