### PR TITLE
chore: bump Go version to 1.26.5

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.26.4
+        go-version: 1.26.5
     -
       name: Check out code into the Go module directory
       uses: actions/checkout@v4

--- a/build/dockerfiles/controller.Dockerfile
+++ b/build/dockerfiles/controller.Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.4-1782736563 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1784190466 AS builder
 ENV GOPATH=/go/
 USER root
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-developer/web-terminal-operator
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/devfile/api/v2 v2.2.0


### PR DESCRIPTION


### What does this PR do?
Update go.mod, CI workflow, and controller Dockerfile to use ubi9/go-toolset 1.26.5-1784190466.


Assisted-by: opencode <big-pickle>

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
